### PR TITLE
Fix db import issues

### DIFF
--- a/.claude/docs/import-pipeline.md
+++ b/.claude/docs/import-pipeline.md
@@ -36,24 +36,22 @@ do {
 
 ## `GET /reprint-db`
 
-Full MySQL dump via `MySQLDumpProducer`, **base64-encoded** and returned as a JSON string literal.
+Full MySQL dump via `MySQLDumpProducer`, returned as a raw SQL string. WP REST wraps the body in a JSON string literal on the wire; the JS consumer calls `await res.json()` to recover the original SQL — no further decoding required.
 
 - DSN: `build_pdo_dsn()` from the Reprint `files` autoload if present, else fallback `mysql:host=…;dbname=…;charset=utf8mb4`.
 - No pagination today.
 - `MySQLDumpProducer` exposes `next_sql_fragment()` / `get_sql_fragment()`, which return **statement-bounded** fragments (not raw byte chunks). If you add a cursor, accumulate fragments until a byte budget, flush, and reuse the producer's re-entrancy mechanism.
-- **Base64 is mandatory.** WP REST always JSON-encodes the response body regardless of the `Content-Type` header, and JSON encoding mangles raw SQL (newlines, embedded quotes, `\u` sequences in string literals). Wrapping the dump in base64 round-trips losslessly through the JSON envelope. Do not "optimise" this away by changing the transport.
 
-JS side hands the decoded bytes to `runSql` from `@wp-playground/blueprints`:
+JS side hands the SQL string to `runSql` from `@wp-playground/blueprints`:
 ```ts
-const b64 = (await res.json()) as string;
-const sqlBytes = base64ToBytes(b64);
-const sqlFile = new File([sqlBytes], 'reprint-import.sql', { type: 'application/sql' });
+const sql = (await res.json()) as string;
+const sqlFile = new File([sql], 'reprint-import.sql', { type: 'application/sql' });
 await runSql(client, { sql: sqlFile });
 ```
 
 `runSql` swallows per-statement failures (it loops `$wpdb->query($q)` and never inspects `last_error`). When `WP_DEBUG` or `SCRIPT_DEBUG` is on, `playground.ts` swaps in `runSqlVerbose`, which executes statements one-by-one and surfaces the first 20 failures to the console. The verbose path uses a hand-rolled splitter that's only correct for Reprint's output (single-quoted `FROM_BASE64('…')` literals — base64 alphabet contains no `'`, `;`, or `\n`); it is **not** a general-purpose SQL splitter.
 
-Pagination is not implemented; `MySQLDumpProducer::next_sql_fragment()` returns statement-bounded fragments, which would make cursor-style chunking straightforward if ever needed. Changing the wire format (e.g. dropping base64, switching to chunked streaming) is an ask-before change — the current contract has no version marker.
+Pagination is not implemented; `MySQLDumpProducer::next_sql_fragment()` returns statement-bounded fragments, which would make cursor-style chunking straightforward if ever needed. Changing the wire format (e.g. switching to chunked streaming) is an ask-before change — the current contract has no version marker.
 
 ## Post-import step
 

--- a/.claude/docs/import-pipeline.md
+++ b/.claude/docs/import-pipeline.md
@@ -36,27 +36,24 @@ do {
 
 ## `GET /reprint-db`
 
-Full MySQL dump via `MySQLDumpProducer` as **`text/plain`** (not JSON).
+Full MySQL dump via `MySQLDumpProducer`, **base64-encoded** and returned as a JSON string literal.
 
 - DSN: `build_pdo_dsn()` from the Reprint `files` autoload if present, else fallback `mysql:host=…;dbname=…;charset=utf8mb4`.
 - No pagination today.
-- `MySQLDumpProducer` exposes `next_sql_fragment()` / `get_sql_fragment()`, which return **statement-bounded** fragments (not raw byte chunks). If you add a cursor, accumulate fragments until a byte budget, flush, and reuse the producer's re-entrancy mechanism. That sidesteps the JS split regex entirely.
-- SQL is UTF-8 and stays **unencoded** in the response — do not base64 it. Base64 on `/reprint-files` exists only for binary safety.
+- `MySQLDumpProducer` exposes `next_sql_fragment()` / `get_sql_fragment()`, which return **statement-bounded** fragments (not raw byte chunks). If you add a cursor, accumulate fragments until a byte budget, flush, and reuse the producer's re-entrancy mechanism.
+- **Base64 is mandatory.** WP REST always JSON-encodes the response body regardless of the `Content-Type` header, and JSON encoding mangles raw SQL (newlines, embedded quotes, `\u` sequences in string literals). Wrapping the dump in base64 round-trips losslessly through the JSON envelope. Do not "optimise" this away by changing the transport.
 
-JS side runs the dump statement-by-statement inside Playground:
+JS side hands the decoded bytes to `runSql` from `@wp-playground/blueprints`:
 ```ts
-await writeFile(client, '/tmp/live-sandbox-import.sql', sql);
-await client.run({ code: `<?php
-  require_once '${docroot}/wp-load.php';
-  global $wpdb;
-  $statements = preg_split('/;[ \\t]*(?:\\r\\n|\\n)/', file_get_contents('${sqlPath}'));
-  foreach ($statements as $s) { if (trim($s) !== '' && !str_starts_with(trim($s), '--')) $wpdb->query($s); }
-`});
+const b64 = (await res.json()) as string;
+const sqlBytes = base64ToBytes(b64);
+const sqlFile = new File([sqlBytes], 'reprint-import.sql', { type: 'application/sql' });
+await runSql(client, { sql: sqlFile });
 ```
 
-The split regex `/;[ \t]*(?:\r\n|\n)/` is load-bearing: naïve splits on `;` break on semicolons inside string literals. Do **not** simplify it.
+`runSql` swallows per-statement failures (it loops `$wpdb->query($q)` and never inspects `last_error`). When `WP_DEBUG` or `SCRIPT_DEBUG` is on, `playground.ts` swaps in `runSqlVerbose`, which executes statements one-by-one and surfaces the first 20 failures to the console. The verbose path uses a hand-rolled splitter that's only correct for Reprint's output (single-quoted `FROM_BASE64('…')` literals — base64 alphabet contains no `'`, `;`, or `\n`); it is **not** a general-purpose SQL splitter.
 
-Pagination is not implemented; `MySQLDumpProducer::next_sql_fragment()` returns statement-bounded fragments, which would make cursor-style chunking straightforward if ever needed. Changing the wire format is an ask-before change — the current `text/plain` contract has no version marker.
+Pagination is not implemented; `MySQLDumpProducer::next_sql_fragment()` returns statement-bounded fragments, which would make cursor-style chunking straightforward if ever needed. Changing the wire format (e.g. dropping base64, switching to chunked streaming) is an ask-before change — the current contract has no version marker.
 
 ## Post-import step
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,38 @@
 # Live Sandbox Editor
 
-WordPress plugin exposing a Monaco editor + WordPress Playground sandbox inside wp-admin. The admin page boots Playground in an iframe, imports the host site's `wp-content` and DB via the Reprint exporter, then lets the user edit files live.
+WordPress plugin exposing a Monaco editor and WordPress Playground sandbox inside wp-admin.
 
-## Layout
+## Scope Map
 
-- `live-sandbox-editor/` — shipped plugin (PHP, REST, built JS). See `live-sandbox-editor/CLAUDE.md` before touching PHP, REST routes, enqueues, or `composer.json`.
-- `src/` — TypeScript frontend (Monaco + Playground client). See `src/CLAUDE.md` before touching any `.ts` file.
-- `assets/blueprints/` — Playground blueprint JSON.
-- `wordpress/` — symlink into a WP checkout for reference only; never edit.
-- `plugin-repo/` — build output (SVN-style); not in git.
+- `live-sandbox-editor/` is the shipped plugin. Follow `live-sandbox-editor/AGENTS.md` before changing PHP, REST routes, enqueues, styles, or plugin Composer files.
+- `src/` is the TypeScript frontend. Follow `src/AGENTS.md` before changing `.ts` files.
+- `assets/blueprints/` contains Playground blueprints.
+- `wordpress/` is a reference checkout only; never edit it.
+- `plugin-repo/` is publishing output; leave it alone unless the task is explicitly about publishing.
 
-## Build / lint
+## Sources Of Truth
 
-- `npm run build` — Vite, outputs to `live-sandbox-editor/build/`. Do **not** swap to `@wordpress/scripts`: webpack breaks Monaco's web workers.
-- `npm run dev` — Vite dev server (not wired to wp-admin; used for isolated Monaco work).
-- `npm run zip` — build + produce `live-sandbox-editor.zip`.
-- `npx biome check .` — JS/TS lint + format check. Add `--write` to auto-fix (`npx biome check . --write`). Config `biome.json`; single quotes, tabs, `recommended` rules.
-- `vendor/bin/phpcs` — PHP lint (WPCS; ruleset `phpcs.xml`, scope limited to `live-sandbox-editor/`). `vendor/bin/phpcbf` auto-fixes the subset it can.
+- Tooling and build details live in `package.json`, `vite.config.ts`, `biome.json`, `tsconfig.json`, and `phpcs.xml`.
+- Import-route details live in `.claude/docs/import-pipeline.md`.
+- PHP-to-JS data handoff details live in `.claude/docs/script-module-data.md`.
+- Testing-harness constraints live in `.claude/docs/testing.md`.
 
-Node/npm pinned via Volta and `.nvmrc` (Node 22). TypeScript is `@typescript/native-preview` — expect occasional surprises vs. stock `tsc`.
+## Verification
 
-## Testing
+- JS/TS: `npx biome check .`
+- PHP: `vendor/bin/phpcs`
+- Build: `npm run build`
+- There is no automated end-to-end suite; verify behavior in a WordPress install when the change affects runtime behavior.
 
-No automated test suite. Verify changes by loading the built plugin in a WP install. Adding a test harness is net-new infra — see `.claude/docs/testing.md` for constraints, stable selectors, REST stubbing, and reasonable defaults before proposing one.
+## Version Bumps
 
-## Version bumps
+For plugin releases, update the plugin header and `VERSION` constant in `live-sandbox-editor/live-sandbox-editor.php`, plus `Stable tag:` in `live-sandbox-editor/readme.txt`.
 
-The plugin version lives in three files; update them together:
-1. `live-sandbox-editor/live-sandbox-editor.php` — `Version:` header **and** the `VERSION` constant.
-2. `live-sandbox-editor/readme.txt` — `Stable tag:` header.
-3. `package.json` — `version` field (root).
-`composer.json` has no `version` field. A `plugin-repo/` SVN bump is only relevant when publishing.
-
-## Runtime dependency
-
-The plugin's REST routes require the **Reprint exporter** classes (`FileTreeProducer`, `WordPress\DataLiberation\MySQLDumpProducer`). They are vendored via Composer in `live-sandbox-editor/composer.json`, but the sibling Reprint plugin, if active, registers them first — the PHP guards against redeclaration. See `live-sandbox-editor/CLAUDE.md`.
+Do not assume root `package.json` is tied to the plugin version unless the release task says so.
 
 ## Boundaries
 
-- Ask before: changing the build toolchain, bumping `@wp-playground/client` (API churn), editing `wordpress/` or `plugin-repo/`, changing the REST transport (the request-response + opaque-cursor contract is load-bearing on both sides).
-- Never: commit `build/`, `vendor/`, or `node_modules/`; ship `wp_localize_script` for this plugin's JS (it's a script module — won't work); widen REST permission callbacks beyond `manage_options`.
-
-## Deep-dive references (`.claude/docs/`)
-
-- `.claude/docs/import-pipeline.md` — full REST route contract (`/reprint-files`, `/reprint-db`), cursor semantics, budget, base64 rationale, statement-split regex. Consult before editing either route or the JS importer.
-- `.claude/docs/script-module-data.md` — PHP↔JS data handoff via `script_module_data_<SLUG>` filter + `getAppData()`. Consult when adding a field that must flow from PHP into JS.
-- `.claude/docs/testing.md` — constraints if you propose adding a test harness.
+- Ask before changing the build toolchain, bumping `@wp-playground/client`, editing `wordpress/` or `plugin-repo/`, changing the REST transport, or adding a test harness.
+- Never commit `build/`, `vendor/`, or `node_modules/`.
+- Never use `wp_localize_script` for this plugin's JS; it is loaded as a script module.
+- Never widen REST permissions beyond `manage_options`.

--- a/live-sandbox-editor/AGENTS.md
+++ b/live-sandbox-editor/AGENTS.md
@@ -18,7 +18,7 @@ Frontend source is in `src/` at the repo root — see `../src/CLAUDE.md`.
 Two routes live under `live-sandbox-editor/v1`, both gated by `current_user_can('manage_options')`, both return 503 when Reprint classes are missing:
 
 - `GET /reprint-files?cursor=…` — cursor-paginated `wp-content` stream via `FileTreeProducer`. JSON `{ files, nextCursor }`, base64 values, ~768 KB budget per response.
-- `GET /reprint-db` — full MySQL dump as `text/plain` via `MySQLDumpProducer`. Not paginated today; if you add pagination, use the producer's statement-bounded `next_sql_fragment()` API (it sidesteps the JS split regex).
+- `GET /reprint-db` — full MySQL dump via `MySQLDumpProducer`, base64-encoded and returned as a JSON string literal (WP REST JSON-encodes the body regardless of `Content-Type`, so the dump must be base64 to survive intact). Not paginated today; if you add pagination, use the producer's statement-bounded `next_sql_fragment()` API.
 
 The only camelCase JSON field in a REST response today is `nextCursor`. Match that style when adding new fields.
 

--- a/live-sandbox-editor/AGENTS.md
+++ b/live-sandbox-editor/AGENTS.md
@@ -1,53 +1,31 @@
-# `live-sandbox-editor/` — shipped plugin
+# `live-sandbox-editor/` — Shipped Plugin
 
-This directory is what gets zipped and installed. PHP bootstrap, built assets, styles, and Composer-vendored Reprint classes.
+This directory is what gets zipped and installed.
 
-## Files
+## Guardrails
 
-- `live-sandbox-editor.php` — single-file bootstrap. Namespace `Live_Sandbox_Editor`, constants `SLUG` / `VERSION`. Registers admin menu, enqueues, two REST routes, and a Reprint-missing admin notice.
-- `style.css` — admin page chrome (`lse-*` classes). Monaco's own CSS is emitted separately to `build/main.css`.
-- `readme.txt` — WordPress.org readme.
-- `composer.json` — requires `wp-php-toolkit/reprint-exporter`. Run `composer install` here (not at repo root).
-- `build/` — Vite output; generated, not in git. See root `CLAUDE.md` for the build command.
-- `vendor/` — Composer output; generated, not in git.
+- `build/` and `vendor/` are generated; never commit them.
+- Run plugin Composer commands from this directory, not the repo root.
+- PHP coding rules are defined in `../phpcs.xml`.
+- User-facing strings use the `live-sandbox-editor` text domain.
+- Global PHP symbols use the `live_sandbox_editor` prefix.
 
-Frontend source is in `src/` at the repo root — see `../src/CLAUDE.md`.
+## REST And Reprint
 
-## REST routes
+Read `../.claude/docs/import-pipeline.md` before editing REST import routes or `../src/playground.ts`.
 
-Two routes live under `live-sandbox-editor/v1`, both gated by `current_user_can('manage_options')`, both return 503 when Reprint classes are missing:
+- Keep import routes under `live-sandbox-editor/v1`.
+- Keep route permissions at `manage_options`.
+- Use `maybe_load_reprint()` before route code that depends on Reprint classes.
+- If Reprint classes are still unavailable, return 503.
+- Preserve the existing request-response contract unless the task explicitly changes the transport.
 
-- `GET /reprint-files?cursor=…` — cursor-paginated `wp-content` stream via `FileTreeProducer`. JSON `{ files, nextCursor }`, base64 values, ~768 KB budget per response.
-- `GET /reprint-db` — full MySQL dump via `MySQLDumpProducer`, base64-encoded and returned as a JSON string literal (WP REST JSON-encodes the body regardless of `Content-Type`, so the dump must be base64 to survive intact). Not paginated today; if you add pagination, use the producer's statement-bounded `next_sql_fragment()` API.
+Ask before bumping `wp-php-toolkit/reprint-exporter`; cursor behavior and the DSN helper are load-bearing.
 
-The only camelCase JSON field in a REST response today is `nextCursor`. Match that style when adding new fields.
+## Script Modules
 
-Wire contract detail — exact shapes, cursor opacity, budget semantics, base64 rationale, statement-split regex, JS consumer snippet — lives in **`.claude/docs/import-pipeline.md`**. Consult it before editing either route or the JS importer in `../src/playground.ts`.
+Read `../.claude/docs/script-module-data.md` before changing PHP data passed to JS.
 
-When adding a route, copy the pattern in `register_rest_routes()`: same namespace (`SLUG . '/v1'`), same permission callback, callback named `rest_<snake_case>`, args sanitised via `sanitize_text_field` or stricter.
-
-## Reprint loading
-
-`maybe_load_reprint()` is the single entry point. It checks for `FileTreeProducer` (global namespace) as a sentinel; if absent, it requires `__DIR__ . '/vendor/autoload.php'`. This avoids a fatal redeclare when the standalone Reprint plugin is also active (it registers its own autoloader first). Call it at the top of any route handler that needs those classes, and return 503 if the class still isn't defined.
-
-`reprint_notice()` is already registered on `admin_notices` and renders an error notice (WordPress `notice notice-error` classes) on the plugin's own page only (it checks `get_current_screen()->id === 'toplevel_page_' . SLUG`). Current message text (translatable, text domain `live-sandbox-editor`):
-
-> Live Sandbox Editor: Reprint classes could not be loaded. Run composer install in the plugin directory.
-
-Plugin directory means `live-sandbox-editor/` (the inner subdirectory, which is where `composer.json` lives — *not* the repo root). If you're adding more user-visible diagnostics, extend this function rather than registering a second notice hook. No separate setup documentation exists; the notice message is the install instruction, kept self-contained. This is the only admin notice the plugin emits — there is no house style beyond standard WordPress conventions (plain imperative tone, no marketing, no emoji, no HTML beyond `<p>` wrappers that WP adds automatically).
-
-## Enqueuing
-
-JS ships as an **ES module** via `wp_enqueue_script_module()`. Data flows through the `script_module_data_<SLUG>` filter — `wp_localize_script` silently does nothing for modules. Full handoff recipe: `.claude/docs/script-module-data.md`.
-
-Enqueue only fires on `hook_suffix === 'toplevel_page_' . SLUG` — the plugin's own top-level menu page.
-
-## Code style
-
-WPCS via `../phpcs.xml`. Scope is this directory only; `vendor/` and `build/` are excluded. Text domain is `live-sandbox-editor`; global prefix is `live_sandbox_editor`. File-comment and Yoda-conditions rules are disabled — don't add them back.
-
-## Boundaries
-
-- Ask before bumping `wp-php-toolkit/reprint-exporter`: chunk-cursor behaviour and the DSN helper are load-bearing.
-- Never commit `build/` or `vendor/`.
-- Never widen the REST permission callback beyond `manage_options` — these routes leak site data.
+- JS is enqueued with `wp_enqueue_script_module()`.
+- Use the `script_module_data_<SLUG>` filter for PHP-to-JS data.
+- Never use `wp_localize_script` for this plugin.

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -293,6 +293,11 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		$sql .= $producer->get_sql_fragment() . "\n";
 	}
 
+	// DEBUG: dump the SQL to a file for inspection.
+	$dump_path = wp_upload_dir()['basedir'] . '/reprint-db-dump.sql';
+	file_put_contents( $dump_path, $sql );
+	error_log( '[live-sandbox-editor] DB dump written to ' . $dump_path );
+
 	return new WP_REST_Response(
 		$sql,
 		200,

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -87,12 +87,16 @@ function enqueue_assets( string $hook_suffix ): void {
 			 *                   restUrl: string;
 			 *                   nonce: string;
 			 *                   siteUrl: string;
+			 *                   scriptDebug: bool;
+			 *                   wpDebug: bool;
 			 *                 }
 			 */
 			$app_data = array(
-				'restUrl' => rest_url( SLUG . '/v1' ),
-				'nonce'   => wp_create_nonce( 'wp_rest' ),
-				'siteUrl' => get_site_url(),
+				'restUrl'     => rest_url( SLUG . '/v1' ),
+				'nonce'       => wp_create_nonce( 'wp_rest' ),
+				'siteUrl'     => get_site_url(),
+				'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && constant( 'SCRIPT_DEBUG' ),
+				'wpDebug'     => defined( 'WP_DEBUG' ) && constant( 'WP_DEBUG' ),
 			);
 			return $app_data;
 		}
@@ -293,8 +297,9 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		$sql .= $producer->get_sql_fragment() . "\n";
 	}
 
+	// Return the SQL as base64 to avoid mangling during the JSON-encoding.
 	return new WP_REST_Response(
-		$sql,
+		base64_encode( $sql ),
 		200,
 		array( 'Content-Type' => 'text/plain; charset=utf-8' )
 	);

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -293,11 +293,6 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		$sql .= $producer->get_sql_fragment() . "\n";
 	}
 
-	// DEBUG: dump the SQL to a file for inspection.
-	$dump_path = wp_upload_dir()['basedir'] . '/reprint-db-dump.sql';
-	file_put_contents( $dump_path, $sql );
-	error_log( '[live-sandbox-editor] DB dump written to ' . $dump_path );
-
 	return new WP_REST_Response(
 		$sql,
 		200,

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -95,8 +95,8 @@ function enqueue_assets( string $hook_suffix ): void {
 				'restUrl'     => rest_url( SLUG . '/v1' ),
 				'nonce'       => wp_create_nonce( 'wp_rest' ),
 				'siteUrl'     => get_site_url(),
-				'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && constant( 'SCRIPT_DEBUG' ),
-				'wpDebug'     => defined( 'WP_DEBUG' ) && constant( 'WP_DEBUG' ),
+				'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+				'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
 			);
 			return $app_data;
 		}
@@ -177,6 +177,8 @@ function register_rest_routes(): void {
  * File contents are base64-encoded so binary assets (images, fonts) survive
  * JSON transport. The JS layer decodes them to Uint8Array before writing to
  * the Playground filesystem.
+ *
+ * @param WP_REST_Request $request The REST request; reads the optional `cursor` query arg.
  */
 function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 	maybe_load_reprint();
@@ -200,7 +202,10 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 		return new WP_Error( 'scan_error', $e->getMessage(), array( 'status' => 500 ) );
 	}
 
-	$cursor = $request->get_param( 'cursor' ) ?: null;
+	$cursor = $request->get_param( 'cursor' );
+	if ( empty( $cursor ) ) {
+		$cursor = null;
+	}
 
 	$producer = new FileTreeProducer(
 		$wp_content_dir,
@@ -213,10 +218,12 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 		)
 	);
 
-	$files         = array();
-	$pending_data  = array(); // path => accumulated raw bytes for multi-chunk files
+	// `$pending_data` accumulates raw bytes per path for multi-chunk files;
+	// `$limit_bytes` caps file data emitted per response (~768 KB).
+	$files          = array();
+	$pending_data   = array();
 	$response_bytes = 0;
-	$limit_bytes   = 768 * 1024; // ~768 KB of file data per response
+	$limit_bytes    = 768 * 1024;
 
 	while ( $producer->next_chunk() ) {
 		$chunk = $producer->get_current_chunk();
@@ -233,7 +240,8 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 		$pending_data[ $rel ] .= $chunk['data'];
 
 		if ( $chunk['is_last_chunk'] ) {
-			$files[ $rel ]   = base64_encode( $pending_data[ $rel ] );
+			// base64 is required to ship raw bytes through the JSON envelope; not obfuscation.
+			$files[ $rel ]   = base64_encode( $pending_data[ $rel ] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$response_bytes += strlen( $pending_data[ $rel ] );
 			unset( $pending_data[ $rel ] );
 
@@ -261,10 +269,15 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 /**
  * REST callback: generate a MySQL dump via MySQLDumpProducer.
  *
- * Returns the full SQL dump as text/plain. For very large databases this may
- * be slow; cursor-based pagination can be added later if needed.
+ * Returns the full SQL dump base64-encoded inside a JSON string body so the
+ * raw bytes survive WP REST's JSON envelope intact. For very large databases
+ * this may be slow; cursor-based pagination can be added later if needed.
+ *
+ * @param WP_REST_Request $request The REST request (no parameters consumed).
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
-function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'WordPress\\DataLiberation\\MySQLDumpProducer' ) ) {
@@ -280,10 +293,13 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 			// Fallback: simple host:dbname DSN sufficient for most single-host setups.
 			$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
 		}
+		// MySQLDumpProducer requires a raw PDO handle — wpdb cannot be used here.
+		// phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
 		$pdo = new \PDO(
 			$dsn,
 			DB_USER,
 			DB_PASSWORD,
+			// phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
 			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
 		);
 	} catch ( \PDOException $e ) {
@@ -297,12 +313,11 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		$sql .= $producer->get_sql_fragment() . "\n";
 	}
 
-	// Return the SQL as base64 to avoid mangling during the JSON-encoding.
-	return new WP_REST_Response(
-		base64_encode( $sql ),
-		200,
-		array( 'Content-Type' => 'text/plain; charset=utf-8' )
-	);
+	// WP REST always JSON-encodes the body, which mangles raw SQL (newlines,
+	// embedded quotes, backslash escapes). Wrap the dump in base64 so it
+	// round-trips losslessly through the JSON envelope; the JS side decodes it.
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	return new WP_REST_Response( base64_encode( $sql ), 200 );
 }
 
 add_action( 'init', __NAMESPACE__ . '\\init' );

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -269,9 +269,10 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 /**
  * REST callback: generate a MySQL dump via MySQLDumpProducer.
  *
- * Returns the full SQL dump base64-encoded inside a JSON string body so the
- * raw bytes survive WP REST's JSON envelope intact. For very large databases
- * this may be slow; cursor-based pagination can be added later if needed.
+ * Returns the full SQL dump as a JSON-encoded string body (WP REST always
+ * JSON-encodes the response, so the JS side parses the envelope with
+ * `res.json()` to recover the raw SQL). For very large databases this may
+ * be slow; cursor-based pagination can be added later if needed.
  *
  * @param WP_REST_Request $request The REST request (no parameters consumed).
  *
@@ -313,11 +314,7 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		$sql .= $producer->get_sql_fragment() . "\n";
 	}
 
-	// WP REST always JSON-encodes the body, which mangles raw SQL (newlines,
-	// embedded quotes, backslash escapes). Wrap the dump in base64 so it
-	// round-trips losslessly through the JSON envelope; the JS side decodes it.
-	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-	return new WP_REST_Response( base64_encode( $sql ), 200 );
+	return new WP_REST_Response( $sql, 200 );
 }
 
 add_action( 'init', __NAMESPACE__ . '\\init' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0",
 			"dependencies": {
+				"@wp-playground/blueprints": "^3.1.20",
 				"@wp-playground/client": "^3.1.20",
 				"monaco-editor": "^0.52.0"
 			},
@@ -575,6 +576,773 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@octokit/app": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+			"integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-app": "^6.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/types": "^12.0.0",
+				"@octokit/webhooks": "^12.0.4"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+			"integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.3.1",
+				"lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+				"universal-github-app-jwt": "^1.1.2",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+			"integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"@types/btoa-lite": "^1.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+			"integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+			"integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+			"integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+			"integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.0.0",
+				"@octokit/auth-oauth-user": "^4.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/oauth-methods": "^4.0.0",
+				"@types/aws-lambda": "^8.10.83",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-authorization-url": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+			"integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+			"integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-graphql": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+			"integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+			"integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.2.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
+		"node_modules/@octokit/webhooks": {
+			"version": "12.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+			"integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/webhooks-methods": "^4.1.0",
+				"@octokit/webhooks-types": "7.6.1",
+				"aggregate-error": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+			"integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-types": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+			"license": "MIT"
+		},
+		"node_modules/@php-wasm/cli-util": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.20.tgz",
+			"integrity": "sha512-zO02i+SpPUF/3O9/JEAmideDiwICzGcoCKssleavwv9sDRr9j7nIokuG9u97T37QgrHX0sap9BGTzZ9C6cgG6w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.20",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/logger": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.20.tgz",
+			"integrity": "sha512-uewkiBJKohKTqcUT3oyi+ijwhW4DiSP9E1wqXdMbIwfFw3ZKKQWuqS0+TsLMt6imR6wTir1jwZwacizVjE6Lcg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.20.tgz",
+			"integrity": "sha512-g1MoBRBit223c3s9WFw6mj0StIfxI7joIwRn1q8lZZCaxRTJ3lTKSsK4IPrXGQcGBPHu+cYWzJ+xiFdGwKmmkw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.20",
+				"@php-wasm/logger": "3.1.20",
+				"@php-wasm/node-7-4": "3.1.20",
+				"@php-wasm/node-8-0": "3.1.20",
+				"@php-wasm/node-8-1": "3.1.20",
+				"@php-wasm/node-8-2": "3.1.20",
+				"@php-wasm/node-8-3": "3.1.20",
+				"@php-wasm/node-8-4": "3.1.20",
+				"@php-wasm/node-8-5": "3.1.20",
+				"@php-wasm/universal": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"@wp-playground/common": "3.1.20",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.20.tgz",
+			"integrity": "sha512-SMSuSBpIERYb7GN5YbePLJjjqClys5jIQrO+s8tJJj2VLkEDzHlyS5CmYWsvkynbzAz5FEBOWtYoVTlVhWzLKw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.20.tgz",
+			"integrity": "sha512-6SdYDZUupzLwMMf/wI+B02H+a9mQcB3tKUuAyVHRz3SzPo3AQcHJCUlASR7G1sP+mQ+F6D6kOTwQdIfgtfcNHA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.20.tgz",
+			"integrity": "sha512-DURvgZLVkDBst+KF/O34A8SM9zdHXKUgafQzc2udxa4uOM+oQ8MHdx9UMOPI9O+T7vSIzDBWHRCwoCHQGa4Cmg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.20.tgz",
+			"integrity": "sha512-ov2r4ZvKAoDa2EdgNo3+jgA0XRwTt08AG8iRsMaqlFBuhCgr7NdaKjonXwoHIg41hfntL/y5cNL4iZlv85eMaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.20.tgz",
+			"integrity": "sha512-d44tJF0PhuQQEt8svtwOnryqnUTyUchsUGziTzw1aaN5C+/pJF3D5L7Gmu9PQn0RXyZua9fpMzuWrIfuWGCiHQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.20.tgz",
+			"integrity": "sha512-f6JjuMdkE3SmK78kqkzXX38tiKKdgeuu/nmpQkUgHDcsnVfwtpgsF23o9XBqIGmkmFOAQ4fivn2oYS+ar/EU+g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.20.tgz",
+			"integrity": "sha512-6GLFSHEzCIFhKWm77bx6fI4+ffxwLh+zQO4U7TNLmU3ZW2Yb6LnsTXn+uWAv6tqUVk5+bXQRgF4bPUd+Jksf1Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.20.tgz",
+			"integrity": "sha512-URARh4wAb+I8p9SJ1gMPov89wEWd2VIe7ikR6kHdKbKWUNsPfyrvuhqDKF+2sMiQWGjLlZenckDRePoMwyrAJw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.20"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.20.tgz",
+			"integrity": "sha512-ia5Vdb8vcqDauewjJJTzklmBgnmxNi5NjUOGltAWzOveecfj8H8v+gdgX4/CDryCgu92EYhCu/Ko1a3x7eO5Vg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.20.tgz",
+			"integrity": "sha512-nAOA7wb0GKtMD2kcgVworVT5wrgmfSS3b5cacM0YUPb4z2uHhmBjhBQTQKVkTc1p3BrzUQpILqrnxVsRVuahNQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.20"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.20.tgz",
+			"integrity": "sha512-ptpup7608diKaq7wVQBkx1BQjpVI+nXRyE/1eg9XehtMCSwTBsW2ykLJfTVwVem9yRGGUNdCdvYlpOesknrGOA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.20",
+				"@php-wasm/progress": "3.1.20",
+				"@php-wasm/stream-compression": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.20.tgz",
+			"integrity": "sha512-5Ad14Y6BO38bWzvSdYvmljREY7iVlkEp9auzh8KtQ8OeymQPvzAafdHuS0dsO5Cv61KC01LQfMZzhn9QlDIeJg==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.20.tgz",
+			"integrity": "sha512-/S3O+QdJ4b88+HMzim1B+drxrYf4NCpAyU+6hbzhN2fL/yiqsGvXVWWGUeegU1dWGicvXA50vlgsfbh1lWMCMA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.20",
+				"@php-wasm/universal": "3.1.20",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.60.2",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -932,12 +1700,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/aws-lambda": {
+			"version": "8.10.161",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+			"integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/btoa-lite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+			"integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
 		},
 		"node_modules/@typescript/native-preview-darwin-arm64": {
 			"version": "7.0.0-dev.20260421.2",
@@ -1037,6 +1842,50 @@
 				"win32"
 			]
 		},
+		"node_modules/@wp-playground/blueprints": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.20.tgz",
+			"integrity": "sha512-+JeN1eWQGhNExlsnMhprPPUOeptYyn0JFTParIoYIQxv+0K3gXYDdOyeQiIBubJa2+usBn9b1VRXI76wgpv3gw==",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.20",
+				"@php-wasm/node": "3.1.20",
+				"@php-wasm/progress": "3.1.20",
+				"@php-wasm/scopes": "3.1.20",
+				"@php-wasm/stream-compression": "3.1.20",
+				"@php-wasm/universal": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"@php-wasm/web-service-worker": "3.1.20",
+				"@wp-playground/common": "3.1.20",
+				"@wp-playground/storage": "3.1.20",
+				"@wp-playground/wordpress": "3.1.20",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wp-playground/client": {
 			"version": "3.1.20",
 			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-3.1.20.tgz",
@@ -1045,6 +1894,535 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/common": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.20.tgz",
+			"integrity": "sha512-F9RAsltz67xzDL9HcJHsVt89w4sUe1ccCioxjEBSkHrDcxb5vw2oSRuFteFkMFZwl1WdXy0c/AtC+xbf0M6C3A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/storage": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.20.tgz",
+			"integrity": "sha512-fchpDqFMOgJAkxTcTbiCDHaigo7DU+s3QInoBmwfYYxJtGzBxCYTjPkEnG2HEJXwLjDpHu2mnFF6ZZm1Cg3BuQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.20",
+				"@php-wasm/universal": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wp-playground/wordpress": {
+			"version": "3.1.20",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.20.tgz",
+			"integrity": "sha512-Ya3LQ6NNpE92AwWye51j5EMpMxJuAZ4BRo5e0F2ZVELw/WAE7GT/N5rFoLp6C+H4hZH9UjlNG/6Xi9L+wkB/ag==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.20",
+				"@php-wasm/node": "3.1.20",
+				"@php-wasm/universal": "3.1.20",
+				"@php-wasm/util": "3.1.20",
+				"@wp-playground/common": "3.1.20",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.7.57",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+			"integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=16.5.0"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+			"license": "MIT"
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"license": "MIT"
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/body-parser": {
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"content-type": "~1.0.5",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.14.0",
+				"raw-body": "~2.5.3",
+				"type-is": "~1.6.18",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"license": "MIT"
+		},
+		"node_modules/btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"license": "MIT"
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+			"license": "MIT"
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"license": "ISC"
+		},
+		"node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/diff3": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"license": "MIT"
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/esbuild": {
@@ -1086,6 +2464,182 @@
 				"@esbuild/win32-x64": "0.21.5"
 			}
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+			"integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.5",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+			"integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "~2.0.2",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fs-ext-extra-prebuilt": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+			"integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"nan": "^2.24.0"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1101,10 +2655,468 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"license": "MIT"
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"license": "MIT"
+		},
+		"node_modules/lru-cache": {
+			"name": "@wolfy1339/lru-cache",
+			"version": "11.0.2-patch.1",
+			"resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+			"integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+			"license": "ISC",
+			"engines": {
+				"node": "18 >=18.20 || 20 || >=22"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5"
+			}
+		},
 		"node_modules/monaco-editor": {
 			"version": "0.52.2",
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
 			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+			"license": "MIT"
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
+		},
+		"node_modules/nan": {
+			"version": "2.26.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
@@ -1126,12 +3138,129 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/octokit": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+			"integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/app": "^14.0.2",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-graphql": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+				"@octokit/plugin-retry": "^6.0.0",
+				"@octokit/plugin-throttling": "^8.0.0",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/postcss": {
 			"version": "8.5.10",
@@ -1160,6 +3289,99 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/rollup": {
@@ -1207,6 +3429,249 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/send": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "~2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "~2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/send/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/serve-static": {
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "~0.19.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"license": "(MIT AND BSD-3-Clause)",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1215,6 +3680,112 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/typescript": {
@@ -1235,6 +3806,70 @@
 				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
 				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
 				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"license": "MIT"
+		},
+		"node_modules/universal-github-app-jwt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+			"integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonwebtoken": "^9.0.0",
+				"jsonwebtoken": "^9.0.2"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"license": "ISC"
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vite": {
@@ -1305,6 +3940,113 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"monaco-editor": ">=0.33.0"
+			}
+		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"author": "sirreal",
 	"license": "GPL-2.0",
 	"dependencies": {
+		"@wp-playground/blueprints": "^3.1.20",
 		"@wp-playground/client": "^3.1.20",
 		"monaco-editor": "^0.52.0"
 	},

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -110,8 +110,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="my-textdomain"/>
-				<element value="library-textdomain"/>
+				<element value="live-sandbox-editor"/>
 			</property>
 		</properties>
 	</rule>

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -35,7 +35,7 @@ Boots Playground and populates its VFS with the host site:
    ```
    Remove the `login` step to land the user logged-out. `steps` accepts any Playground blueprint step; see `@wp-playground/client` types.
 2. Pull `/wp-content` via `GET {restUrl}/reprint-files?cursor=…` (base64 → `Uint8Array` → `writeFile`, looped on opaque cursor).
-3. Pull DB via `GET {restUrl}/reprint-db`, write to `/tmp/live-sandbox-import.sql`, execute statement-by-statement inside Playground.
+3. Pull DB via `GET {restUrl}/reprint-db` (base64-encoded JSON string), decode to `Uint8Array`, hand to `runSql` from `@wp-playground/blueprints`. With `WP_DEBUG`/`SCRIPT_DEBUG`, swap in the local `runSqlVerbose` for per-statement error reporting (writes to `/tmp/lse-import.sql`).
 4. `update_option('siteurl'|'home', …)` with the Playground URL so internal links resolve.
 
 503 from either route means Reprint classes are missing on the host — the pipeline logs and continues without import. Don't hard-fail.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,76 +1,28 @@
-# `src/` — TypeScript frontend
+# `src/` — TypeScript Frontend
 
-Entry is `main.ts`, mounted on `#live-sandbox-editor-root` inside wp-admin. Built by Vite (see root `CLAUDE.md`) into `live-sandbox-editor/build/main.js` + `main.css`, then loaded as an ES module via `wp_enqueue_script_module()`.
+Frontend source for the Monaco editor and WordPress Playground admin app.
 
-## Modules
+## Guardrails
 
-- `main.ts` — DOMContentLoaded → `initApp(root)`. Nothing else belongs here.
-- `app.ts` — builds the DOM (editor pane, file tree, preview iframe, status bar, drag handle), wires tab state, calls `initPlayground`, `initFileExplorer`, `addSaveCommand`. The single orchestrator.
-- `editor.ts` — Monaco lifecycle. One shared `IStandaloneCodeEditor`, per-path `ITextModel` cache, Cmd/Ctrl-S command, extension→language map.
-- `file-explorer.ts` — recursive tree over `PlaygroundClient.listFiles`. Directories sort first; each node lazily renders children on expand.
-- `filesystem.ts` — thin async wrappers over `PlaygroundClient` file ops. Keep it thin; don't let business logic leak in.
-- `playground.ts` — boots Playground via `startPlaygroundWeb`, then pulls `/wp-content` and a SQL dump from the PHP REST routes, writes them into the Playground VFS, and fixes `siteurl`/`home`. See "Import pipeline" below.
-- `types.ts` — shared types plus `getAppData()`, which reads the script-module data blob.
+- Keep the no-framework, imperative DOM style. Do not introduce a framework or JSX without discussion.
+- Relative local imports end in `.js`, even when importing `.ts` source files.
+- CSS lives in `live-sandbox-editor/style.css`; keep app classes under the `lse-` prefix.
+- Keep `filesystem.ts` as thin async wrappers over `PlaygroundClient` file operations.
+- Re-check the installed `@wp-playground/client` signatures before adding new Playground calls.
+- Preserve the dynamic import of `@wp-playground/client`.
 
-## Conventions
+## PHP Data
 
-- Biome enforces single quotes + tabs; imports auto-organized. Run `npx biome check .` before committing.
-- `tsconfig` extends `@tsconfig/strictest`. No implicit any, no unchecked indexed access — expect narrowing work.
-- Relative imports end in `.js` (ESM resolution, even though source is `.ts`). Keep this.
-- DOM built imperatively via the local `el(tag, className)` helper in `app.ts`. No framework, no JSX; don't introduce one without discussion.
-- CSS lives in `live-sandbox-editor/style.css`, not here. Class names use the `lse-` prefix.
+Read `../.claude/docs/script-module-data.md` before changing data passed from PHP to JS.
 
-## Passing data from PHP
+- JS reads data through `getAppData()` in `types.ts`.
+- Adding a field means updating the PHP filter, `AppData`, and consumers together.
+- Never use `wp_localize_script`; script modules do not receive that data.
 
-JS reads a data blob from `#wp-script-module-data-live-sandbox-editor` via `getAppData()` in `types.ts`. **Never** use `wp_localize_script` for this plugin — it's a script module and `wp_localize_script` silently does nothing. Adding a field means updating the PHP filter, the `AppData` interface, and consumers together. Full recipe: `.claude/docs/script-module-data.md`.
+## Import Pipeline
 
-## Import pipeline (`playground.ts`)
+Read `../.claude/docs/import-pipeline.md` before editing `playground.ts` or the PHP import routes.
 
-Boots Playground and populates its VFS with the host site:
-
-1. `startPlaygroundWeb` with blueprint:
-   ```ts
-   { preferredVersions: { wp: 'latest', php: '8.2' },
-     steps: [{ step: 'login', username: 'admin', password: 'password' }] }
-   ```
-   Remove the `login` step to land the user logged-out. `steps` accepts any Playground blueprint step; see `@wp-playground/client` types.
-2. Pull `/wp-content` via `GET {restUrl}/reprint-files?cursor=…` (base64 → `Uint8Array` → `writeFile`, looped on opaque cursor).
-3. Pull DB via `GET {restUrl}/reprint-db` (base64-encoded JSON string), decode to `Uint8Array`, hand to `runSql` from `@wp-playground/blueprints`. With `WP_DEBUG`/`SCRIPT_DEBUG`, swap in the local `runSqlVerbose` for per-statement error reporting (writes to `/tmp/lse-import.sql`).
-4. `update_option('siteurl'|'home', …)` with the Playground URL so internal links resolve.
-
-503 from either route means Reprint classes are missing on the host — the pipeline logs and continues without import. Don't hard-fail.
-
-Full wire contract (shapes, budgets, cursor semantics, statement-split regex, base64 rationale, DB-route pagination recipe): **`.claude/docs/import-pipeline.md`**. Consult it before editing `playground.ts` or either route.
-
-## Tab / app state
-
-All app state is closure-local inside `initApp(root)` in `app.ts`:
-- `openTabs: OpenFile[]` — `OpenFile` is `{ path, label }` (see `types.ts`).
-- `activeTab: string | null`
-- `playgroundClient: PlaygroundClient | null`
-There is no global store, no framework, no persistence — reloading the page loses tab state.
-
-Init order inside `initApp`:
-1. Build DOM (editor pane, file tree, preview iframe, status bar, loading overlay).
-2. `initEditor(monacoContainer)` — Monaco is synchronous.
-3. `initPlayground(iframe, onStatus)` — awaits Playground boot + the whole import pipeline. Blocks everything else.
-4. `initFileExplorer(...)` — needs `client` and `wpContentPath` (= `docroot + '/wp-content'`).
-5. `addSaveCommand(...)` — Cmd/Ctrl-S handler, needs `client`.
-
-## Reading files
-
-`filesystem.ts::readFile` calls `PlaygroundClient.readFileAsText` — text only. The `PlaygroundClient` surface evolves; re-check signatures in `node_modules/@wp-playground/client` before adding new methods.
-
-## Status bar
-
-The status bar is `<div class="lse-status-bar">` containing one `<span class="lse-status-indicator">● <state></state></span>`. `app.ts` mutates its `textContent` directly for progress updates (`● Booting Playground…`, `● Ready`, `● Saved: <file>`). Transient success messages auto-revert to `● Ready` after ~2000ms via `setTimeout`. Errors go to `console.error` with the `[live-sandbox-editor]` prefix; don't surface stack traces to the status bar.
-
-## Keyboard shortcuts
-
-The only shortcut is Cmd/Ctrl-S, registered inside Monaco via `editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, …)` in `editor.ts`. `KeyMod.CtrlCmd` resolves to Cmd on macOS and Ctrl elsewhere.
-
-## Gotchas
-
-- Monaco web workers are wired by `vite-plugin-monaco-editor` at build time. Swapping bundlers requires replicating this.
-- `@wp-playground/client` API evolves fast; always re-check the current `PlaygroundClient` signatures before adding calls.
-- `initPlayground` is imported dynamically (`await import('@wp-playground/client')`) to keep the initial chunk small; preserve that.
+- Treat file-route cursors as opaque pass-through values.
+- File payloads are base64; the DB route returns raw SQL through WP REST's JSON envelope.
+- A 503 from the import routes means Reprint is unavailable; log it and continue without hard-failing the app.

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import {
 import { initFileExplorer } from './file-explorer.js';
 import { readFile, writeFile } from './filesystem.js';
 import { initPlayground } from './playground.js';
-import type { OpenFile } from './types.js';
+import { type OpenFile, getAppData } from './types.js';
 
 export async function initApp(root: HTMLElement): Promise<void> {
 	// --- Build DOM ---
@@ -126,8 +126,13 @@ export async function initApp(root: HTMLElement): Promise<void> {
 		statusText.textContent = '● ' + status;
 	};
 
+	const { scriptDebug, wpDebug } = getAppData();
+
 	try {
-		playgroundClient = await initPlayground(iframe, onStatus);
+		playgroundClient = await initPlayground(iframe, onStatus, {
+			scriptDebug,
+			wpDebug,
+		});
 	} catch (err) {
 		loadingLabel.textContent = 'Playground failed to initialize.';
 		console.error('[live-sandbox-editor] Playground init error:', err);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,10 +1,15 @@
+import { runSql } from '@wp-playground/blueprints';
 import {
 	type PlaygroundClient,
 	startPlaygroundWeb,
 } from '@wp-playground/client';
-import { runSql } from '@wp-playground/blueprints';
 import { ensureDir, writeFile } from './filesystem.js';
 import { getAppData } from './types.js';
+
+export interface DebugSettings {
+	scriptDebug: boolean;
+	wpDebug: boolean;
+}
 
 async function getErrorResponseText(res: Response): Promise<string | null> {
 	try {
@@ -18,7 +23,10 @@ async function getErrorResponseText(res: Response): Promise<string | null> {
 export async function initPlayground(
 	iframe: HTMLIFrameElement,
 	onStatus: (status: string) => void,
+	debug: DebugSettings,
 ): Promise<PlaygroundClient> {
+	const debugMode = debug.scriptDebug || debug.wpDebug;
+
 	onStatus('Booting Playground…');
 	const client = await startPlaygroundWeb({
 		iframe,
@@ -29,12 +37,16 @@ export async function initPlayground(
 		},
 	});
 
+	if (debugMode) {
+		await logSqliteIntegrationVersion(client);
+	}
+
 	onStatus('Importing site files…');
 	const filesOk = await importReprintFiles(client);
 
 	if (filesOk) {
 		onStatus('Importing database…');
-		await importReprintDb(client);
+		await importReprintDb(client, debugMode);
 
 		onStatus('Fixing site URL…');
 		await fixSiteUrl(client);
@@ -42,6 +54,65 @@ export async function initPlayground(
 
 	await client.goTo('/');
 	return client;
+}
+
+/**
+ * Log the bundled sqlite-database-integration plugin version and whether
+ * the FROM_BASE64 UDF (added in PR #326, first tagged in v2.2.23) is wired up.
+ * Reprint dumps wrap every non-numeric column in FROM_BASE64('…'), so without
+ * this UDF every INSERT silently fails through the runSql layer.
+ */
+async function logSqliteIntegrationVersion(
+	client: PlaygroundClient,
+): Promise<void> {
+	const result = await client.run({
+		code: `<?php
+			$candidates = array(
+				'/internal/shared/sqlite-database-integration/load.php',
+				'/wp-content/mu-plugins/sqlite-database-integration/load.php',
+				'/wp-content/plugins/sqlite-database-integration/load.php',
+			);
+			$found = null;
+			foreach ($candidates as $p) {
+				if (file_exists($p)) { $found = $p; break; }
+			}
+			$version = null;
+			if ($found) {
+				$header = file_get_contents($found, false, null, 0, 4096);
+				if (preg_match('/^[ \\t\\/*#@]*Version:\\s*(.+)$/mi', $header, $m)) {
+					$version = trim($m[1]);
+				}
+			}
+			$has_from_base64 = false;
+			$udf_path = null;
+			if ($found) {
+				$dir = dirname($found);
+				foreach (array(
+					// v3.0.0+ layout (monorepo restructure, PR #334).
+					$dir . '/wp-includes/database/sqlite/class-wp-sqlite-pdo-user-defined-functions.php',
+					// pre-v3 layout.
+					$dir . '/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php',
+					$dir . '/wp-includes/sqlite-ast/class-wp-sqlite-pdo-user-defined-functions.php',
+				) as $u) {
+					if (file_exists($u)) {
+						$udf_path = $u;
+						$has_from_base64 = (false !== strpos(file_get_contents($u), 'from_base64'));
+						break;
+					}
+				}
+			}
+			echo json_encode(array(
+				'pluginPath' => $found,
+				'version' => $version,
+				'udfPath' => $udf_path,
+				'hasFromBase64' => $has_from_base64,
+			));
+		`,
+	});
+	console.log(
+		'[live-sandbox-editor] sqlite-database-integration:',
+		JSON.parse(result.text),
+	);
 }
 
 /**
@@ -103,7 +174,10 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	return true;
 }
 
-async function importReprintDb(client: PlaygroundClient): Promise<void> {
+async function importReprintDb(
+	client: PlaygroundClient,
+	debugMode: boolean,
+): Promise<void> {
 	const { restUrl, nonce } = getAppData();
 	const res = await fetch(`${restUrl}/reprint-db`, {
 		headers: { 'X-WP-Nonce': nonce },
@@ -126,10 +200,130 @@ async function importReprintDb(client: PlaygroundClient): Promise<void> {
 		return;
 	}
 
-	const sqlFile = new File([await res.blob()], 'reprint-import.sql', {
-		type: 'application/sql',
+	// The backend wraps the SQL dump in base64 to survive WP REST's JSON
+	// envelope intact (the Content-Type header is cosmetic — WP REST always
+	// JSON-encodes the body, which would otherwise mangle newlines/quotes
+	// inside the SQL). res.json() unwraps the JSON string literal; the
+	// base64 alphabet then round-trips losslessly into bytes.
+	const b64 = (await res.json()) as string;
+	const sqlBytes = base64ToBytes(b64);
+
+	if (debugMode) {
+		await runSqlVerbose(client, sqlBytes);
+	} else {
+		const sqlFile = new File([sqlBytes], 'reprint-import.sql', {
+			type: 'application/sql',
+		});
+		await runSql(client, { sql: sqlFile });
+	}
+}
+
+/**
+ * Replacement for `runSql()` that captures per-statement failures.
+ *
+ * `runSql` (from `@wp-playground/blueprints`) calls `$wpdb->query($q)` in a
+ * loop and never inspects the return value or `$wpdb->last_error`, so a dump
+ * causing errors looks identical to a successful import from the JS side.
+ * This loop does the same per-statement execution but records and returns
+ * the first N failures so we can see them in the console.
+ *
+ * The statement splitter is intentionally tiny: Reprint dumps only emit
+ * single-quoted string literals inside `FROM_BASE64('…')` (base64 alphabet
+ * has no `'`, `;`, or `\n`), so a state machine that toggles on `'` and cuts
+ * on `;` is enough. Standard SQL `''` escape is handled too.
+ */
+async function runSqlVerbose(
+	client: PlaygroundClient,
+	sqlBytes: Uint8Array,
+): Promise<void> {
+	const docroot = await client.documentRoot;
+	const sqlPath = '/tmp/lse-import.sql';
+	await writeFile(client, sqlPath, sqlBytes);
+
+	const result = await client.run({
+		code: `<?php
+			define('WP_SQLITE_AST_DRIVER', true);
+			require_once '${docroot}/wp-load.php';
+			global $wpdb;
+			$wpdb->suppress_errors();
+			$wpdb->hide_errors();
+
+			$sql = file_get_contents(${JSON.stringify(sqlPath)});
+			$len = strlen($sql);
+			$i = 0;
+			$start = 0;
+			$in_str = false;
+			$ok = 0;
+			$fail = 0;
+			$errors = array();
+			$max_errors = 20;
+
+			$exec = function ($stmt) use (&$wpdb, &$ok, &$fail, &$errors, $max_errors) {
+				$stmt = trim($stmt);
+				if ($stmt === '' || $stmt === ';') return;
+				$wpdb->last_error = '';
+				$r = $wpdb->query($stmt);
+				if ($r === false || $wpdb->last_error !== '') {
+					$fail++;
+					if (count($errors) < $max_errors) {
+						$errors[] = array(
+							'error' => $wpdb->last_error,
+							'sql'   => substr($stmt, 0, 400),
+						);
+					}
+				} else {
+					$ok++;
+				}
+			};
+
+			while ($i < $len) {
+				$c = $sql[$i];
+				if (!$in_str) {
+					if ($c === "'") {
+						$in_str = true;
+					} elseif ($c === ';') {
+						$exec(substr($sql, $start, $i - $start + 1));
+						$start = $i + 1;
+					}
+				} else {
+					if ($c === "'") {
+						if ($i + 1 < $len && $sql[$i + 1] === "'") {
+							$i++;
+						} else {
+							$in_str = false;
+						}
+					}
+				}
+				$i++;
+			}
+			if ($start < $len) {
+				$exec(substr($sql, $start));
+			}
+
+			echo json_encode(array(
+				'ok' => $ok,
+				'fail' => $fail,
+				'sampleErrors' => $errors,
+			));
+		`,
 	});
-	await runSql(client, { sql: sqlFile });
+	const summary = JSON.parse(result.text) as {
+		ok: number;
+		fail: number;
+		sampleErrors: Array<{ error: string; sql: string }>;
+	};
+	if (summary.fail > 0) {
+		console.warn(
+			`[live-sandbox-editor] DB import: ${summary.ok} ok, ${summary.fail} failed`,
+		);
+		for (const e of summary.sampleErrors) {
+			console.warn('[live-sandbox-editor] failed stmt:', e.error, '\n', e.sql);
+		}
+	} else {
+		console.log(
+			`[live-sandbox-editor] DB import: ${summary.ok} statements applied cleanly`,
+		);
+	}
 }
 
 async function fixSiteUrl(client: PlaygroundClient): Promise<void> {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -197,19 +197,16 @@ async function importReprintDb(
 		return;
 	}
 
-	// The backend wraps the SQL dump in base64 to survive WP REST's JSON
-	// envelope intact (the Content-Type header is cosmetic — WP REST always
-	// JSON-encodes the body, which would otherwise mangle newlines/quotes
-	// inside the SQL). res.json() unwraps the JSON string literal; the
-	// base64 alphabet then round-trips losslessly into bytes.
-	const b64 = (await res.json()) as string;
-	const sqlBytes = base64ToBytes(b64);
+	// WP REST always JSON-encodes the response body. Parse the envelope to
+	// recover the raw SQL — the cosmetic Content-Type doesn't change the
+	// fact that the body is a JSON string literal.
+	const sql = (await res.json()) as string;
 
 	if (debugMode) {
-		await runSqlVerbose(client, b64);
+		await runSqlVerbose(client, sql);
 	} else {
 		const { runSql } = await import('@wp-playground/blueprints');
-		const sqlFile = new File([sqlBytes], 'reprint-import.sql', {
+		const sqlFile = new File([sql], 'reprint-import.sql', {
 			type: 'application/sql',
 		});
 		await runSql(client, { sql: sqlFile });
@@ -219,11 +216,10 @@ async function importReprintDb(
 /**
  * Replacement for `runSql()` that captures per-statement failures.
  *
- * `runSql` (from `@wp-playground/blueprints`) calls `$wpdb->query($q)` in a
- * loop and never inspects the return value or `$wpdb->last_error`, so a dump
- * causing errors looks identical to a successful import from the JS side.
- * This loop does the same per-statement execution but records and returns
- * the first N failures so we can see them in the console.
+ * `runSql` (from `@wp-playground/blueprints`) ignores `$wpdb->query()` return
+ * values and `$wpdb->last_error`, so a failing dump looks identical to a
+ * successful import. We re-run the same execution loop but record the first
+ * N failures and surface them in the console.
  *
  * The splitter handles `--` line comments and `/* …` block comments before
  * applying the in-string state machine, so an apostrophe inside a comment
@@ -233,16 +229,17 @@ async function importReprintDb(
  * non-numeric column in `FROM_BASE64('…')` and never emits double-quoted
  * strings or backslash escapes. If the producer ever changes shape, audit
  * this splitter.
- *
- * The base64 payload is embedded directly in the PHP snippet (via
- * `JSON.stringify`, safe because base64 contains no characters that need
- * JSON escaping) and decoded server-side, so no temp file is required.
  */
 async function runSqlVerbose(
 	client: PlaygroundClient,
-	sqlBase64: string,
+	sql: string,
 ): Promise<void> {
 	const docroot = await client.documentRoot;
+	// Round-tripping the SQL via a temp file (rather than embedding it as a
+	// PHP string literal) avoids JSON-vs-PHP escape rule mismatches and
+	// keeps memory use bounded for large dumps.
+	const sqlPath = '/tmp/lse-verbose-import.sql';
+	await client.writeFile(sqlPath, new TextEncoder().encode(sql));
 
 	const result = await client.run({
 		code: `<?php
@@ -251,7 +248,7 @@ async function runSqlVerbose(
 			$wpdb->suppress_errors();
 			$wpdb->hide_errors();
 
-			$sql = base64_decode(${JSON.stringify(sqlBase64)});
+			$sql = file_get_contents('${sqlPath}');
 			$len = strlen($sql);
 			$i = 0;
 			$start = 0;
@@ -282,13 +279,11 @@ async function runSqlVerbose(
 			while ($i < $len) {
 				$c = $sql[$i];
 				if (!$in_str) {
-					// Skip '--' line comments to end-of-line.
 					if ($c === '-' && $i + 1 < $len && $sql[$i + 1] === '-') {
 						$nl = strpos($sql, "\\n", $i);
 						$i = ($nl === false) ? $len : $nl + 1;
 						continue;
 					}
-					// Skip /* ... */ block comments.
 					if ($c === '/' && $i + 1 < $len && $sql[$i + 1] === '*') {
 						$end = strpos($sql, '*/', $i + 2);
 						$i = ($end === false) ? $len : $end + 2;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -21,7 +21,7 @@ export async function initPlayground(
 	});
 
 	onStatus('Importing site files…');
-	const filesOk = await importReprintFiles(client);
+	const filesOk = true || (await importReprintFiles(client));
 
 	if (filesOk) {
 		onStatus('Importing database…');
@@ -30,6 +30,9 @@ export async function initPlayground(
 		onStatus('Fixing site URL…');
 		await fixSiteUrl(client);
 	}
+
+	// Debug: dump the SQLite database as a downloadable blob URL
+	await dumpSqliteBlob(client);
 
 	await client.goTo('/');
 	return client;
@@ -64,6 +67,7 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 		}
 
 		if (!res.ok) {
+			throw res;
 			console.error(
 				'[live-sandbox-editor] Reprint file import failed:',
 				res.status,
@@ -106,6 +110,7 @@ async function importReprintDb(client: PlaygroundClient): Promise<void> {
 	}
 
 	if (!res.ok) {
+		throw res;
 		console.error(
 			'[live-sandbox-editor] Reprint DB import failed:',
 			res.status,
@@ -130,6 +135,26 @@ async function fixSiteUrl(client: PlaygroundClient): Promise<void> {
 			update_option('home', '${playgroundUrl}');
 		`,
 	});
+}
+
+async function dumpSqliteBlob(client: PlaygroundClient): Promise<void> {
+	const docroot = await client.documentRoot;
+	const sqlitePath = `${docroot}/wp-content/database/.ht.sqlite`;
+	try {
+		const result = await client.run({
+			code: `<?php echo base64_encode(file_get_contents('${sqlitePath}'));`,
+		});
+		const b64 = result.text;
+		const bytes = Uint8Array.fromBase64(b64);
+		const blob = new Blob([bytes], { type: 'application/x-sqlite3' });
+		const url = URL.createObjectURL(blob);
+		console.log(
+			'[live-sandbox-editor] SQLite blob URL (paste into browser address bar to download):',
+			url,
+		);
+	} catch (e) {
+		console.error('[live-sandbox-editor] Failed to read SQLite database:', e);
+	}
 }
 
 function base64ToBytes(b64: string): Uint8Array {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,8 +1,4 @@
-import { runSql } from '@wp-playground/blueprints';
-import {
-	type PlaygroundClient,
-	startPlaygroundWeb,
-} from '@wp-playground/client';
+import type { PlaygroundClient } from '@wp-playground/client';
 import { ensureDir, writeFile } from './filesystem.js';
 import { getAppData } from './types.js';
 
@@ -26,6 +22,7 @@ export async function initPlayground(
 	debug: DebugSettings,
 ): Promise<PlaygroundClient> {
 	const debugMode = debug.scriptDebug || debug.wpDebug;
+	const { startPlaygroundWeb } = await import('@wp-playground/client');
 
 	onStatus('Booting Playground…');
 	const client = await startPlaygroundWeb({
@@ -209,8 +206,9 @@ async function importReprintDb(
 	const sqlBytes = base64ToBytes(b64);
 
 	if (debugMode) {
-		await runSqlVerbose(client, sqlBytes);
+		await runSqlVerbose(client, b64);
 	} else {
+		const { runSql } = await import('@wp-playground/blueprints');
 		const sqlFile = new File([sqlBytes], 'reprint-import.sql', {
 			type: 'application/sql',
 		});
@@ -227,28 +225,33 @@ async function importReprintDb(
  * This loop does the same per-statement execution but records and returns
  * the first N failures so we can see them in the console.
  *
- * The statement splitter is intentionally tiny: Reprint dumps only emit
- * single-quoted string literals inside `FROM_BASE64('…')` (base64 alphabet
- * has no `'`, `;`, or `\n`), so a state machine that toggles on `'` and cuts
- * on `;` is enough. Standard SQL `''` escape is handled too.
+ * The splitter handles `--` line comments and `/* …` block comments before
+ * applying the in-string state machine, so an apostrophe inside a comment
+ * (e.g. `-- Dumping data for table 'foo'`) doesn't flip parsing state. The
+ * in-string machine itself only recognises single-quoted literals (with
+ * SQL `''` escape) — this matches Reprint's output, which wraps every
+ * non-numeric column in `FROM_BASE64('…')` and never emits double-quoted
+ * strings or backslash escapes. If the producer ever changes shape, audit
+ * this splitter.
+ *
+ * The base64 payload is embedded directly in the PHP snippet (via
+ * `JSON.stringify`, safe because base64 contains no characters that need
+ * JSON escaping) and decoded server-side, so no temp file is required.
  */
 async function runSqlVerbose(
 	client: PlaygroundClient,
-	sqlBytes: Uint8Array,
+	sqlBase64: string,
 ): Promise<void> {
 	const docroot = await client.documentRoot;
-	const sqlPath = '/tmp/lse-import.sql';
-	await writeFile(client, sqlPath, sqlBytes);
 
 	const result = await client.run({
 		code: `<?php
-			define('WP_SQLITE_AST_DRIVER', true);
 			require_once '${docroot}/wp-load.php';
 			global $wpdb;
 			$wpdb->suppress_errors();
 			$wpdb->hide_errors();
 
-			$sql = file_get_contents(${JSON.stringify(sqlPath)});
+			$sql = base64_decode(${JSON.stringify(sqlBase64)});
 			$len = strlen($sql);
 			$i = 0;
 			$start = 0;
@@ -279,6 +282,18 @@ async function runSqlVerbose(
 			while ($i < $len) {
 				$c = $sql[$i];
 				if (!$in_str) {
+					// Skip '--' line comments to end-of-line.
+					if ($c === '-' && $i + 1 < $len && $sql[$i + 1] === '-') {
+						$nl = strpos($sql, "\\n", $i);
+						$i = ($nl === false) ? $len : $nl + 1;
+						continue;
+					}
+					// Skip /* ... */ block comments.
+					if ($c === '/' && $i + 1 < $len && $sql[$i + 1] === '*') {
+						$end = strpos($sql, '*/', $i + 2);
+						$i = ($end === false) ? $len : $end + 2;
+						continue;
+					}
 					if ($c === "'") {
 						$in_str = true;
 					} elseif ($c === ';') {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -21,7 +21,7 @@ export async function initPlayground(
 	});
 
 	onStatus('Importing site files…');
-	const filesOk = true || (await importReprintFiles(client));
+	const filesOk = await importReprintFiles(client);
 
 	if (filesOk) {
 		onStatus('Importing database…');
@@ -30,9 +30,6 @@ export async function initPlayground(
 		onStatus('Fixing site URL…');
 		await fixSiteUrl(client);
 	}
-
-	// Debug: dump the SQLite database as a downloadable blob URL
-	await dumpSqliteBlob(client);
 
 	await client.goTo('/');
 	return client;
@@ -67,7 +64,6 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 		}
 
 		if (!res.ok) {
-			throw res;
 			console.error(
 				'[live-sandbox-editor] Reprint file import failed:',
 				res.status,
@@ -110,7 +106,6 @@ async function importReprintDb(client: PlaygroundClient): Promise<void> {
 	}
 
 	if (!res.ok) {
-		throw res;
 		console.error(
 			'[live-sandbox-editor] Reprint DB import failed:',
 			res.status,
@@ -135,26 +130,6 @@ async function fixSiteUrl(client: PlaygroundClient): Promise<void> {
 			update_option('home', '${playgroundUrl}');
 		`,
 	});
-}
-
-async function dumpSqliteBlob(client: PlaygroundClient): Promise<void> {
-	const docroot = await client.documentRoot;
-	const sqlitePath = `${docroot}/wp-content/database/.ht.sqlite`;
-	try {
-		const result = await client.run({
-			code: `<?php echo base64_encode(file_get_contents('${sqlitePath}'));`,
-		});
-		const b64 = result.text;
-		const bytes = Uint8Array.fromBase64(b64);
-		const blob = new Blob([bytes], { type: 'application/x-sqlite3' });
-		const url = URL.createObjectURL(blob);
-		console.log(
-			'[live-sandbox-editor] SQLite blob URL (paste into browser address bar to download):',
-			url,
-		);
-	} catch (e) {
-		console.error('[live-sandbox-editor] Failed to read SQLite database:', e);
-	}
 }
 
 function base64ToBytes(b64: string): Uint8Array {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,12 +1,14 @@
-import type { PlaygroundClient } from '@wp-playground/client';
+import type { PlaygroundClient, runSql } from '@wp-playground/client';
 import { ensureDir, writeFile } from './filesystem.js';
 import { getAppData } from './types.js';
+
+type RunSql = typeof runSql;
 
 export async function initPlayground(
 	iframe: HTMLIFrameElement,
 	onStatus: (status: string) => void,
 ): Promise<PlaygroundClient> {
-	const { startPlaygroundWeb } = await import('@wp-playground/client');
+	const { startPlaygroundWeb, runSql } = await import('@wp-playground/client');
 
 	onStatus('Booting Playground…');
 	const client = await startPlaygroundWeb({
@@ -23,7 +25,7 @@ export async function initPlayground(
 
 	if (filesOk) {
 		onStatus('Importing database…');
-		await importReprintDb(client);
+		await importReprintDb(client, runSql);
 
 		onStatus('Fixing site URL…');
 		await fixSiteUrl(client);
@@ -90,7 +92,10 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	return true;
 }
 
-async function importReprintDb(client: PlaygroundClient): Promise<void> {
+async function importReprintDb(
+	client: PlaygroundClient,
+	runSql: RunSql,
+): Promise<void> {
 	const { restUrl, nonce } = getAppData();
 	const res = await fetch(`${restUrl}/reprint-db`, {
 		headers: { 'X-WP-Nonce': nonce },
@@ -111,44 +116,10 @@ async function importReprintDb(client: PlaygroundClient): Promise<void> {
 		return;
 	}
 
-	const sql = await res.text();
-	const docroot = await client.documentRoot;
-	const sqlPath = '/tmp/live-sandbox-import.sql';
-
-	await writeFile(client, sqlPath, sql);
-
-    const result = await client.run({
-		code: String.raw`<?php
-        require_once '${docroot}/wp-load.php';
-        global $wpdb;
-        $sql = file_get_contents('${sqlPath}');
-        // MySQL dumps terminate each statement with ";\n".
-        // Splitting on that avoids false splits on semicolons inside string values.
-        // $statements = preg_split('/;[ \\t]*(?:\\r\\n|\\n)/', $sql);
-        $statements = preg_split('/;$/m', $sql);
-        $errors = [];
-        foreach ($statements as $statement) {
-            $statement = trim($statement);
-            // Skip blank lines and SQL comment lines (-- style).
-            if ($statement === '' || str_starts_with($statement, '--')) {
-                continue;
-            }
-            if (false === $wpdb->query($statement)) {
-                $errors[] = $wpdb->last_error . ': ' . substr($statement, 0, 120);
-            }
-        }
-        if ($errors) {
-            echo implode("\\n", array_slice($errors, 0, 20));
-        }
-    `,
+	const sqlFile = new File([await res.blob()], 'reprint-import.sql', {
+		type: 'application/sql',
 	});
-
-	if (result.text?.trim()) {
-		console.warn(
-			'[live-sandbox-editor] DB import warnings:\n',
-			result.text.trim(),
-		);
-	}
+	await runSql(client, { sql: sqlFile });
 }
 
 async function fixSiteUrl(client: PlaygroundClient): Promise<void> {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,15 +1,15 @@
-import type { PlaygroundClient, runSql } from '@wp-playground/client';
+import {
+	type PlaygroundClient,
+	startPlaygroundWeb,
+} from '@wp-playground/client';
+import { runSql } from '@wp-playground/blueprints';
 import { ensureDir, writeFile } from './filesystem.js';
 import { getAppData } from './types.js';
-
-type RunSql = typeof runSql;
 
 export async function initPlayground(
 	iframe: HTMLIFrameElement,
 	onStatus: (status: string) => void,
 ): Promise<PlaygroundClient> {
-	const { startPlaygroundWeb, runSql } = await import('@wp-playground/client');
-
 	onStatus('Booting Playground…');
 	const client = await startPlaygroundWeb({
 		iframe,
@@ -25,7 +25,7 @@ export async function initPlayground(
 
 	if (filesOk) {
 		onStatus('Importing database…');
-		await importReprintDb(client, runSql);
+		await importReprintDb(client);
 
 		onStatus('Fixing site URL…');
 		await fixSiteUrl(client);
@@ -92,10 +92,7 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	return true;
 }
 
-async function importReprintDb(
-	client: PlaygroundClient,
-	runSql: RunSql,
-): Promise<void> {
+async function importReprintDb(client: PlaygroundClient): Promise<void> {
 	const { restUrl, nonce } = getAppData();
 	const res = await fetch(`${restUrl}/reprint-db`, {
 		headers: { 'X-WP-Nonce': nonce },

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface AppData {
 	restUrl: string;
 	nonce: string;
 	siteUrl: string;
+	scriptDebug: boolean;
+	wpDebug: boolean;
 }
 
 export function getAppData(): AppData {


### PR DESCRIPTION
Fix the db import issues by avoiding the mangling of the SQL data that was happening due to the REST API JSON-encoding the SQL string.

The response is now a base64-encoded string that will survive the JSON-serialization intact, will be base64-decoded on the JS/TS side and correctly imported.

[Screencast](https://cleanshot.com/share/6Gdl1d0f)

While working on this I was frustrated by the lack of visibility into issues that might arise while importing the SQL dump in the `runSql` step.
For this reason I've added and put behind a debug flag a more verbose `runSqlVerbose` function that leverages the reprint DB format (where strings that might break a naïve SQL statement string are base64-encoded) to execute the statements one by one and report possible issues.
