### PR TITLE
Composer file automation

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,12 +1,10 @@
 {
-  "config": {
-    "WP_DEBUG": true,
-    "WP_DEBUG_DISPLAY": true,
-    "SCRIPT_DEBUG": true,
-    "WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
-  },
-  "plugins": [
-    "./live-sandbox-editor"
-  ],
-  "testsEnvironment": false
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"SCRIPT_DEBUG": true,
+		"WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
+	},
+	"plugins": ["./live-sandbox-editor"],
+	"testsEnvironment": false
 }

--- a/composer.json
+++ b/composer.json
@@ -7,19 +7,15 @@
 		"install-plugin-vendor": [
 			"@composer install --working-dir=live-sandbox-editor --no-scripts --no-dev"
 		],
-		"post-install-cmd": [
-			"@install-plugin-vendor"
-		],
-		"post-update-cmd": [
-			"@install-plugin-vendor"
-		]
+		"post-install-cmd": ["@install-plugin-vendor"],
+		"post-update-cmd": ["@install-plugin-vendor"]
 	},
 	"scripts-descriptions": {
 		"install-plugin-vendor": "Install the live-sandbox-editor plugin's runtime dependencies (from live-sandbox-editor/plugin-composer.json) into live-sandbox-editor/vendor/. Runs automatically after every composer install/update at the repo root."
 	},
 	"config": {
 		"allow-plugins": {
-		"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,23 @@
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^3.0"
 	},
+	"scripts": {
+		"install-plugin-vendor": [
+			"@composer install --working-dir=live-sandbox-editor --no-scripts --no-dev"
+		],
+		"post-install-cmd": [
+			"@install-plugin-vendor"
+		],
+		"post-update-cmd": [
+			"@install-plugin-vendor"
+		]
+	},
+	"scripts-descriptions": {
+		"install-plugin-vendor": "Install the live-sandbox-editor plugin's runtime dependencies (from live-sandbox-editor/plugin-composer.json) into live-sandbox-editor/vendor/. Runs automatically after every composer install/update at the repo root."
+	},
 	"config": {
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+		"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/live-sandbox-editor/AGENTS.md
+++ b/live-sandbox-editor/AGENTS.md
@@ -5,7 +5,7 @@ This directory is what gets zipped and installed.
 ## Guardrails
 
 - `build/` and `vendor/` are generated; never commit them.
-- Run plugin Composer commands from this directory, not the repo root.
+- Composer is driven from the repo root: `composer install` / `composer update` populate this directory's `vendor/` via a post-install script. To operate on the plugin manifest directly, use `COMPOSER=plugin-composer.json composer <cmd> --working-dir=live-sandbox-editor` from the repo root.
 - PHP coding rules are defined in `../phpcs.xml`.
 - User-facing strings use the `live-sandbox-editor` text domain.
 - Global PHP symbols use the `live_sandbox_editor` prefix.

--- a/live-sandbox-editor/AGENTS.md
+++ b/live-sandbox-editor/AGENTS.md
@@ -5,7 +5,7 @@ This directory is what gets zipped and installed.
 ## Guardrails
 
 - `build/` and `vendor/` are generated; never commit them.
-- Composer is driven from the repo root: `composer install` / `composer update` populate this directory's `vendor/` via a post-install script. To operate on the plugin manifest directly, use `COMPOSER=plugin-composer.json composer <cmd> --working-dir=live-sandbox-editor` from the repo root.
+- Composer is driven from the repo root: `composer install` / `composer update` populate this directory's `vendor/` via a post-install script that runs `composer install --working-dir=live-sandbox-editor --no-scripts --no-dev` against `live-sandbox-editor/composer.json` (the plugin's runtime manifest). To operate on the plugin manifest directly, run `composer <cmd> --working-dir=live-sandbox-editor` from the repo root, or `cd live-sandbox-editor` and run `composer <cmd>` from there.
 - PHP coding rules are defined in `../phpcs.xml`.
 - User-facing strings use the `live-sandbox-editor` text domain.
 - Global PHP symbols use the `live_sandbox_editor` prefix.

--- a/live-sandbox-editor/composer.lock
+++ b/live-sandbox-editor/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0"
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/664b3f6930afcd057acd3eb92370ba99853858f0",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
                 "shasum": ""
             },
             "require": {
@@ -52,30 +52,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
             },
-            "time": "2025-09-11T23:53:08+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1",
-                "wp-php-toolkit/http-client": "^0.5.1",
-                "wp-php-toolkit/xml": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2",
+                "wp-php-toolkit/http-client": "^0.6.2",
+                "wp-php-toolkit/xml": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -107,22 +107,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a"
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/aafe834847cc45133836b0462f22fa1511eb3b5a",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
                 "shasum": ""
             },
             "require": {
@@ -156,27 +156,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -210,22 +210,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92"
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
                 "shasum": ""
             },
             "require": {
@@ -260,29 +260,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
             },
-            "time": "2025-09-08T13:34:24+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -313,30 +313,30 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.1.45",
+            "version": "v0.1.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
-                "reference": "679f2ba88278ec8646593cc1389b2511c9c7d33d"
+                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/679f2ba88278ec8646593cc1389b2511c9c7d33d",
-                "reference": "679f2ba88278ec8646593cc1389b2511c9c7d33d",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/3c56b78f4d19add36f8448421d1ed4fdda135bb6",
+                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1"
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -362,27 +362,27 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.45"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.47"
             },
-            "time": "2026-04-17T22:11:46+00:00"
+            "time": "2026-04-27T14:34:36+00:00"
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.5.1"
+                "wp-php-toolkit/encoding": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -413,9 +413,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         }
     ],
     "packages-dev": [],

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -133,7 +133,7 @@ function reprint_notice(): void {
 		return;
 	}
 	echo '<div class="notice notice-error"><p>';
-	esc_html_e( 'Live Sandbox Editor: Reprint classes could not be loaded. Run composer install in the plugin directory.', 'live-sandbox-editor' );
+	esc_html_e( 'Live Sandbox Editor: Reprint classes could not be loaded. Run composer install in the project root directory.', 'live-sandbox-editor' );
 	echo '</p></div>';
 }
 


### PR DESCRIPTION
Add post-install and post-update hooks in the root `composer.json` file to install/update the plugin dependencies.

## Why not use `composer-installers`?
In theory using the `composer-installers` package would allow a single root `composer.json` file to install in the  plugin directory, but there are two issues:

1. The `wp-php-toolkit/reprint-exporter` [package `type` is `library`](https://github.com/wp-php-toolkit/reprint-exporter/blob/main/composer.json#L4) which is not [a supported `composer-installers` type](https://github.com/composer/installers#current-supported-package-types). This would require the use of something like [oomphinc/composer-installers-extender](oomphinc/composer-installers-extender) which was last updated 5 years ago.
2. It would break the autoload in the plugin since the autoload file would be in the root `vendor` directory.

For these reasons I opted for a simpler solution that will support installing everything with one `composer install` or `compooser update` from the root directory and leverages the two separated `composer.json` files (root and plugin) for finer control.

