### PR TITLE
Avoid OOM errors, stream files and sql

### DIFF
--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -247,7 +247,7 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'FileTreeProducer' ) ) {
-		http_response_code( 503 );
+		http_response_code( 500 );
 		stream_ndjson_setup();
 		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'Reprint classes not available.' ) );
 		exit;
@@ -263,7 +263,7 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 			$paths[] = $file->getPathname();
 		}
 	} catch ( \UnexpectedValueException $e ) {
-		http_response_code( 503 );
+		http_response_code( 500 );
 		stream_ndjson_setup();
 		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'scan_error: ' . $e->getMessage() ) );
 		exit;

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -245,6 +245,9 @@ function stream_ndjson_emit( array $record ): void {
  * bounded by chunk size (no per-file accumulation, no response array).
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ *
+ * @param  WP_REST_Request $request Request.
+ * @return WP_Error|void
  */
 function rest_reprint_files( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	maybe_load_reprint();
@@ -357,6 +360,8 @@ function rest_reprint_files( WP_REST_Request $request ) { // phpcs:ignore Generi
  * largest single fragment (~max_allowed_packet).
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ *
+ * @param  WP_REST_Request $request Request.
  */
 function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	maybe_load_reprint();

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -19,9 +19,7 @@ namespace Live_Sandbox_Editor;
 use FileTreeProducer;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use WP_Error;
 use WP_REST_Request;
-use WP_REST_Response;
 use WordPress\DataLiberation\MySQLDumpProducer;
 
 const SLUG    = 'live-sandbox-editor';
@@ -170,13 +168,6 @@ function register_rest_routes(): void {
 			'methods'             => 'GET',
 			'permission_callback' => fn() => current_user_can( 'manage_options' ),
 			'callback'            => __NAMESPACE__ . '\\rest_reprint_files',
-			'args'                => array(
-				'cursor' => array(
-					'type'              => 'string',
-					'required'          => false,
-					'sanitize_callback' => 'sanitize_text_field',
-				),
-			),
 		)
 	);
 
@@ -192,29 +183,77 @@ function register_rest_routes(): void {
 }
 
 /**
- * REST callback: stream wp-content files via FileTreeProducer.
+ * Prepare a streaming NDJSON response: drop output buffers, disable
+ * compression/buffering middleware, send the header set, and return.
  *
- * Returns JSON: { files: { "/wp-content/...": "<base64>" }, nextCursor: string|null }
- * Iterates at most ~768 KB of file data per request; pass nextCursor back as
- * ?cursor= to resume. nextCursor is null when the export is complete.
- *
- * File contents are base64-encoded so binary assets (images, fonts) survive
- * JSON transport. The JS layer decodes them to Uint8Array before writing to
- * the Playground filesystem.
- *
- * @param WP_REST_Request $request The REST request; reads the optional `cursor` query arg.
+ * Caller is responsible for echoing one JSON object per line (terminated
+ * with "\n"), calling flush() after each, and exiting before the WP REST
+ * dispatcher tries to wrap a return value.
  */
-function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+function stream_ndjson_setup(): void {
+	while ( ob_get_level() > 0 ) {
+		ob_end_clean();
+	}
+	@ini_set( 'zlib.output_compression', '0' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	if ( function_exists( 'apache_setenv' ) ) {
+		@apache_setenv( 'no-gzip', '1' );
+	}
+	// Streaming a full wp-content / DB dump comfortably exceeds the default
+	// 30s max_execution_time. Disable it for this request and call
+	// set_time_limit() again periodically inside the loop in case the host
+	// silently re-imposes a per-iteration timer.
+	@set_time_limit( 0 );
+	// Keep producing data even if the browser tab closes — half-written files
+	// in Playground are useless, so we'd rather finish the stream.
+	ignore_user_abort( true );
+	if ( function_exists( 'session_write_close' ) ) {
+		@session_write_close();
+	}
+	nocache_headers();
+	header( 'Content-Type: application/x-ndjson; charset=utf-8' );
+	header( 'Cache-Control: no-cache, no-store, no-transform, must-revalidate' );
+	header( 'Pragma: no-cache' );
+	// nginx: opt this response out of proxy_buffering.
+	header( 'X-Accel-Buffering: no' );
+	// Defeat compression middleware that otherwise buffers entire body.
+	header( 'Content-Encoding: identity' );
+	header( 'X-Content-Type-Options: nosniff' );
+	// Deliberately no Content-Length — its absence forces chunked transfer.
+}
+
+/**
+ * Emit a single NDJSON record and flush.
+ *
+ * @param array $record Record payload — JSON-encoded as one line.
+ */
+function stream_ndjson_emit( array $record ): void {
+	echo wp_json_encode( $record ), "\n";
+	flush();
+}
+
+/**
+ * REST callback: stream wp-content files as NDJSON.
+ *
+ * Each line is one chunk of one file:
+ *   { "t":"f", "path":"/wp-content/…", "b64":"…", "seq":N, "final":bool }
+ *
+ * The handler bypasses WP_REST_Response and exits directly so the body is
+ * streamed without WP's JSON-envelope buffering. PHP peak memory stays
+ * bounded by chunk size (no per-file accumulation, no response array).
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'FileTreeProducer' ) ) {
-		return new WP_Error( 'reprint_unavailable', 'Reprint classes not available.', array( 'status' => 503 ) );
+		stream_ndjson_setup();
+		stream_ndjson_emit( array( 't' => 'err', 'message' => 'Reprint classes not available.' ) );
+		exit;
 	}
 
 	$wp_content_dir = rtrim( WP_CONTENT_DIR, '/' );
 
-	// Build the full path list that FileTreeProducer requires on every request.
-	// Directory iteration is fast; the producer handles cursor-based positioning.
 	$paths = array();
 	try {
 		$rdi = new RecursiveDirectoryIterator( $wp_content_dir, RecursiveDirectoryIterator::SKIP_DOTS );
@@ -223,90 +262,83 @@ function rest_reprint_files( WP_REST_Request $request ): WP_REST_Response|WP_Err
 			$paths[] = $file->getPathname();
 		}
 	} catch ( \UnexpectedValueException $e ) {
-		return new WP_Error( 'scan_error', $e->getMessage(), array( 'status' => 500 ) );
+		stream_ndjson_setup();
+		stream_ndjson_emit( array( 't' => 'err', 'message' => 'scan_error: ' . $e->getMessage() ) );
+		exit;
 	}
 
-	$cursor = $request->get_param( 'cursor' );
-	if ( empty( $cursor ) ) {
-		$cursor = null;
-	}
+	stream_ndjson_setup();
 
+	// Small chunks keep PHP peak memory bounded regardless of file size; the
+	// underlying FileTreeProducer reads files in $chunk_size pieces.
 	$producer = new FileTreeProducer(
 		$wp_content_dir,
 		array(
 			'paths'      => $paths,
-			// Large chunk size so most WP files are single-chunk; prevents
-			// splitting a file's binary data across two REST responses.
-			'chunk_size' => 8 * 1024 * 1024,
-			'cursor'     => $cursor,
+			'chunk_size' => 256 * 1024,
 		)
 	);
 
-	// `$pending_data` accumulates raw bytes per path for multi-chunk files;
-	// `$limit_bytes` caps file data emitted per response (~768 KB).
-	$files          = array();
-	$pending_data   = array();
-	$response_bytes = 0;
-	$limit_bytes    = 768 * 1024;
+	$content_prefix_len = strlen( $wp_content_dir );
+	$emitted            = 0;
 
-	while ( $producer->next_chunk() ) {
-		$chunk = $producer->get_current_chunk();
-		if ( ! $chunk || $chunk['type'] !== 'file' ) {
-			continue;
-		}
+	try {
+		while ( $producer->next_chunk() ) {
+			$chunk = $producer->get_current_chunk();
+			if ( ! $chunk || $chunk['type'] !== 'file' ) {
+				continue;
+			}
 
-		// Convert absolute server path → relative wp-content path.
-		$rel = '/wp-content' . substr( $chunk['path'], strlen( $wp_content_dir ) );
+			$rel = '/wp-content' . substr( $chunk['path'], $content_prefix_len );
 
-		if ( ! isset( $pending_data[ $rel ] ) ) {
-			$pending_data[ $rel ] = '';
-		}
-		$pending_data[ $rel ] .= $chunk['data'];
+			stream_ndjson_emit(
+				array(
+					't'     => 'f',
+					'path'  => $rel,
+					'b64'   => base64_encode( $chunk['data'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+					'seq'   => (int) ( $chunk['offset'] ?? 0 ),
+					'final' => (bool) ( $chunk['is_last_chunk'] ?? false ),
+				)
+			);
 
-		if ( $chunk['is_last_chunk'] ) {
-			// base64 is required to ship raw bytes through the JSON envelope; not obfuscation.
-			$files[ $rel ]   = base64_encode( $pending_data[ $rel ] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-			$response_bytes += strlen( $pending_data[ $rel ] );
-			unset( $pending_data[ $rel ] );
-
-			// Stop at a file boundary once the budget is spent.
-			if ( $response_bytes >= $limit_bytes ) {
-				break;
+			// Reset the wall-clock budget every so often: some hosts reapply
+			// max_execution_time after each request hook even when we set 0
+			// up front, and the loop can run for minutes on big sites.
+			if ( ( ++$emitted % 64 ) === 0 ) {
+				@set_time_limit( 0 );
+				if ( connection_aborted() ) {
+					exit;
+				}
 			}
 		}
+	} catch ( \Throwable $e ) {
+		stream_ndjson_emit( array( 't' => 'err', 'message' => $e->getMessage() ) );
+		exit;
 	}
 
-	// Determine whether there is more data to fetch.
-	$cursor_data = json_decode( $producer->get_reentrancy_cursor(), true );
-	$next_cursor = ( isset( $cursor_data['phase'] ) && 'finished' !== $cursor_data['phase'] )
-		? $producer->get_reentrancy_cursor()
-		: null;
-
-	return new WP_REST_Response(
-		array(
-			'files'      => $files,
-			'nextCursor' => $next_cursor,
-		)
-	);
+	stream_ndjson_emit( array( 't' => 'end' ) );
+	exit;
 }
 
 /**
- * REST callback: generate a MySQL dump via MySQLDumpProducer.
+ * REST callback: stream a MySQL dump as NDJSON.
  *
- * Returns the full SQL dump as a JSON-encoded string body (WP REST always
- * JSON-encodes the response, so the JS side parses the envelope with
- * `res.json()` to recover the raw SQL). For very large databases this may
- * be slow; cursor-based pagination can be added later if needed.
+ * Each line is one SQL fragment from MySQLDumpProducer:
+ *   { "t":"sql", "b64":"…" }
  *
- * @param WP_REST_Request $request The REST request (no parameters consumed).
+ * Fragments are base64-encoded so embedded newlines/binary bytes don't
+ * break NDJSON line framing. PHP peak memory stays bounded by the
+ * largest single fragment (~max_allowed_packet).
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
-function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'WordPress\\DataLiberation\\MySQLDumpProducer' ) ) {
-		return new WP_Error( 'reprint_unavailable', 'Reprint classes not available.', array( 'status' => 503 ) );
+		stream_ndjson_setup();
+		stream_ndjson_emit( array( 't' => 'err', 'message' => 'Reprint classes not available.' ) );
+		exit;
 	}
 
 	try {
@@ -315,10 +347,8 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 		if ( function_exists( 'build_pdo_dsn' ) ) {
 			$dsn = build_pdo_dsn( DB_HOST, DB_NAME );
 		} else {
-			// Fallback: simple host:dbname DSN sufficient for most single-host setups.
 			$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
 		}
-		// MySQLDumpProducer requires a raw PDO handle — wpdb cannot be used here.
 		// phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
 		$pdo = new \PDO(
 			$dsn,
@@ -328,17 +358,43 @@ function rest_reprint_db( WP_REST_Request $request ): WP_REST_Response|WP_Error 
 			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
 		);
 	} catch ( \PDOException $e ) {
-		return new WP_Error( 'db_connect', 'Database connection failed: ' . $e->getMessage(), array( 'status' => 500 ) );
+		stream_ndjson_setup();
+		stream_ndjson_emit( array( 't' => 'err', 'message' => 'db_connect: ' . $e->getMessage() ) );
+		exit;
 	}
+
+	stream_ndjson_setup();
 
 	$producer = new MySQLDumpProducer( $pdo );
+	$emitted  = 0;
 
-	$sql = '';
-	while ( $producer->next_sql_fragment() ) {
-		$sql .= $producer->get_sql_fragment() . "\n";
+	try {
+		while ( $producer->next_sql_fragment() ) {
+			$fragment = $producer->get_sql_fragment();
+			if ( null === $fragment ) {
+				continue;
+			}
+			stream_ndjson_emit(
+				array(
+					't'   => 'sql',
+					'b64' => base64_encode( $fragment . "\n" ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				)
+			);
+
+			if ( ( ++$emitted % 64 ) === 0 ) {
+				@set_time_limit( 0 );
+				if ( connection_aborted() ) {
+					exit;
+				}
+			}
+		}
+	} catch ( \Throwable $e ) {
+		stream_ndjson_emit( array( 't' => 'err', 'message' => $e->getMessage() ) );
+		exit;
 	}
 
-	return new WP_REST_Response( $sql, 200 );
+	stream_ndjson_emit( array( 't' => 'end' ) );
+	exit;
 }
 
 add_action( 'init', __NAMESPACE__ . '\\init' );

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -361,7 +361,7 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
 		);
 	} catch ( \PDOException $e ) {
-		http_response_code( 503 );
+		http_response_code( 500 );
 		stream_ndjson_setup();
 		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'db_connect: ' . $e->getMessage() ) );
 		exit;

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -235,7 +235,7 @@ function stream_ndjson_emit( array $record ): void {
  * REST callback: stream wp-content files as NDJSON.
  *
  * Each line is one chunk of one file:
- *   { "t":"f", "path":"/wp-content/…", "b64":"…", "seq":N, "final":bool }
+ *   { "type":"file", "path":"/wp-content/…", "b64":"…", "seq":N, "final":bool }
  *
  * The handler bypasses WP_REST_Response and exits directly so the body is
  * streamed without WP's JSON-envelope buffering. PHP peak memory stays
@@ -247,8 +247,9 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'FileTreeProducer' ) ) {
+		http_response_code( 503 );
 		stream_ndjson_setup();
-		stream_ndjson_emit( array( 't' => 'err', 'message' => 'Reprint classes not available.' ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'Reprint classes not available.' ) );
 		exit;
 	}
 
@@ -262,8 +263,9 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 			$paths[] = $file->getPathname();
 		}
 	} catch ( \UnexpectedValueException $e ) {
+		http_response_code( 503 );
 		stream_ndjson_setup();
-		stream_ndjson_emit( array( 't' => 'err', 'message' => 'scan_error: ' . $e->getMessage() ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'scan_error: ' . $e->getMessage() ) );
 		exit;
 	}
 
@@ -293,7 +295,7 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 
 			stream_ndjson_emit(
 				array(
-					't'     => 'f',
+					'type'  => 'file',
 					'path'  => $rel,
 					'b64'   => base64_encode( $chunk['data'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 					'seq'   => (int) ( $chunk['offset'] ?? 0 ),
@@ -312,11 +314,11 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
 			}
 		}
 	} catch ( \Throwable $e ) {
-		stream_ndjson_emit( array( 't' => 'err', 'message' => $e->getMessage() ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => $e->getMessage() ) );
 		exit;
 	}
 
-	stream_ndjson_emit( array( 't' => 'end' ) );
+	stream_ndjson_emit( array( 'type' => 'end' ) );
 	exit;
 }
 
@@ -324,7 +326,7 @@ function rest_reprint_files( WP_REST_Request $request ): void { // phpcs:ignore 
  * REST callback: stream a MySQL dump as NDJSON.
  *
  * Each line is one SQL fragment from MySQLDumpProducer:
- *   { "t":"sql", "b64":"…" }
+ *   { "type":"sql", "b64":"…" }
  *
  * Fragments are base64-encoded so embedded newlines/binary bytes don't
  * break NDJSON line framing. PHP peak memory stays bounded by the
@@ -336,8 +338,9 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 	maybe_load_reprint();
 
 	if ( ! class_exists( 'WordPress\\DataLiberation\\MySQLDumpProducer' ) ) {
+		http_response_code( 503 );
 		stream_ndjson_setup();
-		stream_ndjson_emit( array( 't' => 'err', 'message' => 'Reprint classes not available.' ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'Reprint classes not available.' ) );
 		exit;
 	}
 
@@ -358,8 +361,9 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
 		);
 	} catch ( \PDOException $e ) {
+		http_response_code( 503 );
 		stream_ndjson_setup();
-		stream_ndjson_emit( array( 't' => 'err', 'message' => 'db_connect: ' . $e->getMessage() ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'db_connect: ' . $e->getMessage() ) );
 		exit;
 	}
 
@@ -376,8 +380,8 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 			}
 			stream_ndjson_emit(
 				array(
-					't'   => 'sql',
-					'b64' => base64_encode( $fragment . "\n" ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+					'type' => 'sql',
+					'b64'  => base64_encode( $fragment . "\n" ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				)
 			);
 
@@ -389,11 +393,11 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 			}
 		}
 	} catch ( \Throwable $e ) {
-		stream_ndjson_emit( array( 't' => 'err', 'message' => $e->getMessage() ) );
+		stream_ndjson_emit( array( 'type' => 'err', 'message' => $e->getMessage() ) );
 		exit;
 	}
 
-	stream_ndjson_emit( array( 't' => 'end' ) );
+	stream_ndjson_emit( array( 'type' => 'end' ) );
 	exit;
 }
 

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -227,7 +227,7 @@ function stream_ndjson_setup(): void {
  * @param array $record Record payload — JSON-encoded as one line.
  */
 function stream_ndjson_emit( array $record ): void {
-	echo wp_json_encode( $record ), "\n";
+	echo wp_json_encode( $record, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS ), "\n";
 	flush();
 }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -117,8 +117,7 @@ async function logSqliteIntegrationVersion(
  * disk. Files are appended chunk-by-chunk via FILE_APPEND inside Playground;
  * the JS heap never holds a full file or a buffered response body.
  *
- * Returns true on success, false if the server reports the Reprint classes
- * are unavailable (handled gracefully so the rest of the boot continues).
+ * Returns true on success, false if the server reports an error.
  */
 async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	const { restUrl, nonce } = getAppData();
@@ -127,13 +126,6 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	const res = await fetch(`${restUrl}/reprint-files`, {
 		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
 	});
-
-	if (res.status === 503) {
-		console.warn(
-			'[live-sandbox-editor] Reprint classes unavailable — skipping file import.',
-		);
-		return false;
-	}
 
 	if (!res.ok) {
 		const errorText = await getErrorResponseText(res);
@@ -176,13 +168,6 @@ async function importReprintDb(
 	const res = await fetch(`${restUrl}/reprint-db`, {
 		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
 	});
-
-	if (res.status === 503) {
-		console.warn(
-			'[live-sandbox-editor] Reprint classes unavailable — skipping DB import.',
-		);
-		return;
-	}
 
 	if (!res.ok) {
 		const errorText = await getErrorResponseText(res);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,5 +1,5 @@
 import type { PlaygroundClient } from '@wp-playground/client';
-import { ensureDir, writeFile } from './filesystem.js';
+import { BatchedDiskFlusher, readNdjson } from './streaming.js';
 import { getAppData } from './types.js';
 
 export interface DebugSettings {
@@ -113,71 +113,68 @@ async function logSqliteIntegrationVersion(
 }
 
 /**
- * Fetch wp-content files from the REST proxy and write them into Playground.
+ * Stream wp-content files from the REST proxy directly into Playground
+ * disk. Files are appended chunk-by-chunk via FILE_APPEND inside Playground;
+ * the JS heap never holds a full file or a buffered response body.
  *
- * PHP returns file contents as base64 (so binary assets survive JSON).
- * We decode each value to a Uint8Array before handing it to writeFile().
- *
- * Returns true if files were successfully imported, false on failure.
+ * Returns true on success, false if the server reports the Reprint classes
+ * are unavailable (handled gracefully so the rest of the boot continues).
  */
 async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 	const { restUrl, nonce } = getAppData();
 	const docroot = await client.documentRoot;
-	let cursor: string | null = null;
 
-	do {
-		const params = new URLSearchParams();
-		if (cursor) params.set('cursor', cursor);
+	const res = await fetch(`${restUrl}/reprint-files`, {
+		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
+	});
 
-		const res = await fetch(`${restUrl}/reprint-files?${params.toString()}`, {
-			headers: { 'X-WP-Nonce': nonce },
+	if (res.status === 503) {
+		console.warn(
+			'[live-sandbox-editor] Reprint classes unavailable — skipping file import.',
+		);
+		return false;
+	}
+
+	if (!res.ok) {
+		const errorText = await getErrorResponseText(res);
+		console.error(
+			'[live-sandbox-editor] Reprint file import failed:',
+			res.status,
+			errorText ?? '',
+		);
+		return false;
+	}
+
+	const flusher = new BatchedDiskFlusher(client);
+
+	try {
+		await readNdjson(res, async (rec) => {
+			if (rec.t !== 'f') return;
+			const fullPath = docroot + rec.path;
+			await flusher.addFileChunk(fullPath, rec.b64, rec.seq === 0);
 		});
-
-		if (res.status === 503) {
-			console.warn(
-				'[live-sandbox-editor] Reprint classes unavailable — skipping file import.',
-			);
-			return false;
-		}
-
-		if (!res.ok) {
-			const errorText = await getErrorResponseText(res);
-			console.error(
-				'[live-sandbox-editor] Reprint file import failed:',
-				res.status,
-				errorText ?? '',
-			);
-			return false;
-		}
-
-		const data = (await res.json()) as {
-			files: Record<string, string>;
-			nextCursor: string | null;
-		};
-
-		for (const [relativePath, b64Content] of Object.entries(data.files)) {
-			const fullPath = docroot + relativePath;
-			const dir = fullPath.substring(0, fullPath.lastIndexOf('/'));
-			await ensureDir(client, dir);
-			// Decode base64 → Uint8Array so binary files (images, fonts) are
-			// written correctly. PlaygroundClient.writeFile accepts Uint8Array.
-			const bytes = base64ToBytes(b64Content);
-			await writeFile(client, fullPath, bytes);
-		}
-
-		cursor = data.nextCursor;
-	} while (cursor);
+		await flusher.flush();
+	} catch (err) {
+		console.error('[live-sandbox-editor] File stream failed:', err);
+		return false;
+	}
 
 	return true;
 }
 
+/**
+ * Stream the SQL dump from the REST proxy straight to a file inside
+ * Playground, then execute it via an in-Playground splitter that reads
+ * from disk. The full SQL never lives in JS or PHP memory — both sides
+ * are bounded by the flusher's batch size.
+ */
 async function importReprintDb(
 	client: PlaygroundClient,
 	debugMode: boolean,
 ): Promise<void> {
 	const { restUrl, nonce } = getAppData();
 	const res = await fetch(`${restUrl}/reprint-db`, {
-		headers: { 'X-WP-Nonce': nonce },
+		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
 	});
 
 	if (res.status === 503) {
@@ -197,49 +194,46 @@ async function importReprintDb(
 		return;
 	}
 
-	// WP REST always JSON-encodes the response body. Parse the envelope to
-	// recover the raw SQL — the cosmetic Content-Type doesn't change the
-	// fact that the body is a JSON string literal.
-	const sql = (await res.json()) as string;
+	const flusher = new BatchedDiskFlusher(client);
+	await flusher.resetSqlFile();
 
-	if (debugMode) {
-		await runSqlVerbose(client, sql);
-	} else {
-		const { runSql } = await import('@wp-playground/blueprints');
-		const sqlFile = new File([sql], 'reprint-import.sql', {
-			type: 'application/sql',
+	try {
+		await readNdjson(res, async (rec) => {
+			if (rec.t !== 'sql') return;
+			await flusher.addSqlChunk(rec.b64);
 		});
-		await runSql(client, { sql: sqlFile });
+		await flusher.flush();
+	} catch (err) {
+		console.error('[live-sandbox-editor] DB stream failed:', err);
+		return;
 	}
+
+	await runSqlFromDisk(client, flusher.getSqlPath(), debugMode);
 }
 
 /**
- * Replacement for `runSql()` that captures per-statement failures.
+ * Execute a SQL dump that's already on disk inside Playground.
  *
- * `runSql` (from `@wp-playground/blueprints`) ignores `$wpdb->query()` return
- * values and `$wpdb->last_error`, so a failing dump looks identical to a
- * successful import. We re-run the same execution loop but record the first
- * N failures and surface them in the console.
+ * Uses an in-PHP statement splitter that handles `--` line comments and
+ * `/* …` block comments before applying the in-string state machine, so an
+ * apostrophe inside a comment (e.g. `-- Dumping data for table 'foo'`)
+ * doesn't flip parsing state. The in-string machine itself only recognises
+ * single-quoted literals (with SQL `''` escape) — this matches Reprint's
+ * output, which wraps every non-numeric column in `FROM_BASE64('…')` and
+ * never emits double-quoted strings or backslash escapes. If the producer
+ * ever changes shape, audit this splitter.
  *
- * The splitter handles `--` line comments and `/* …` block comments before
- * applying the in-string state machine, so an apostrophe inside a comment
- * (e.g. `-- Dumping data for table 'foo'`) doesn't flip parsing state. The
- * in-string machine itself only recognises single-quoted literals (with
- * SQL `''` escape) — this matches Reprint's output, which wraps every
- * non-numeric column in `FROM_BASE64('…')` and never emits double-quoted
- * strings or backslash escapes. If the producer ever changes shape, audit
- * this splitter.
+ * `runSql()` from `@wp-playground/blueprints` ignores `$wpdb->query()`
+ * return values and `$wpdb->last_error`, so a failing dump looks identical
+ * to a successful import. This loop tracks per-statement results; in debug
+ * mode the first N failures are surfaced.
  */
-async function runSqlVerbose(
+async function runSqlFromDisk(
 	client: PlaygroundClient,
-	sql: string,
+	sqlPath: string,
+	debugMode: boolean,
 ): Promise<void> {
 	const docroot = await client.documentRoot;
-	// Round-tripping the SQL via a temp file (rather than embedding it as a
-	// PHP string literal) avoids JSON-vs-PHP escape rule mismatches and
-	// keeps memory use bounded for large dumps.
-	const sqlPath = '/tmp/lse-verbose-import.sql';
-	await client.writeFile(sqlPath, new TextEncoder().encode(sql));
 
 	const result = await client.run({
 		code: `<?php
@@ -258,7 +252,7 @@ async function runSqlVerbose(
 			$errors = array();
 			$max_errors = 20;
 
-			$exec = function ($stmt) use (&$wpdb, &$ok, &$fail, &$errors, $max_errors) {
+			$run_stmt = function ($stmt) use (&$wpdb, &$ok, &$fail, &$errors, $max_errors) {
 				$stmt = trim($stmt);
 				if ($stmt === '' || $stmt === ';') return;
 				$wpdb->last_error = '';
@@ -292,7 +286,7 @@ async function runSqlVerbose(
 					if ($c === "'") {
 						$in_str = true;
 					} elseif ($c === ';') {
-						$exec(substr($sql, $start, $i - $start + 1));
+						$run_stmt(substr($sql, $start, $i - $start + 1));
 						$start = $i + 1;
 					}
 				} else {
@@ -307,7 +301,7 @@ async function runSqlVerbose(
 				$i++;
 			}
 			if ($start < $len) {
-				$exec(substr($sql, $start));
+				$run_stmt(substr($sql, $start));
 			}
 
 			echo json_encode(array(
@@ -317,6 +311,7 @@ async function runSqlVerbose(
 			));
 		`,
 	});
+
 	const summary = JSON.parse(result.text) as {
 		ok: number;
 		fail: number;
@@ -326,8 +321,15 @@ async function runSqlVerbose(
 		console.warn(
 			`[live-sandbox-editor] DB import: ${summary.ok} ok, ${summary.fail} failed`,
 		);
-		for (const e of summary.sampleErrors) {
-			console.warn('[live-sandbox-editor] failed stmt:', e.error, '\n', e.sql);
+		if (debugMode) {
+			for (const e of summary.sampleErrors) {
+				console.warn(
+					'[live-sandbox-editor] failed stmt:',
+					e.error,
+					'\n',
+					e.sql,
+				);
+			}
 		}
 	} else {
 		console.log(
@@ -347,8 +349,4 @@ async function fixSiteUrl(client: PlaygroundClient): Promise<void> {
 			update_option('home', '${playgroundUrl}');
 		`,
 	});
-}
-
-function base64ToBytes(b64: string): Uint8Array {
-	return Uint8Array.fromBase64(b64);
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -149,7 +149,7 @@ async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
 
 	try {
 		await readNdjson(res, async (rec) => {
-			if (rec.t !== 'f') return;
+			if (rec.type !== 'file') return;
 			const fullPath = docroot + rec.path;
 			await flusher.addFileChunk(fullPath, rec.b64, rec.seq === 0);
 		});
@@ -199,7 +199,7 @@ async function importReprintDb(
 
 	try {
 		await readNdjson(res, async (rec) => {
-			if (rec.t !== 'sql') return;
+			if (rec.type !== 'sql') return;
 			await flusher.addSqlChunk(rec.b64);
 		});
 		await flusher.flush();

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,0 +1,165 @@
+import type { PlaygroundClient } from '@wp-playground/client';
+
+export type NdjsonRecord =
+	| { t: 'f'; path: string; b64: string; seq: number; final: boolean }
+	| { t: 'sql'; b64: string }
+	| { t: 'end' }
+	| { t: 'err'; message: string };
+
+/**
+ * Read an NDJSON response body line by line, invoking `onRecord` for each
+ * parsed JSON object. Resolves cleanly only when the server emits a final
+ * `{t:"end"}` record; throws on `{t:"err"}` or premature EOF.
+ *
+ * Uses the streaming `TextDecoder` flag so multi-byte UTF-8 sequences split
+ * across chunk boundaries are joined correctly.
+ */
+export async function readNdjson(
+	res: Response,
+	onRecord: (rec: NdjsonRecord) => Promise<void>,
+): Promise<void> {
+	if (!res.body) {
+		throw new Error('Response has no body');
+	}
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder('utf-8');
+	let buf = '';
+	let sawEnd = false;
+
+	while (!sawEnd) {
+		const { value, done } = await reader.read();
+		if (done) {
+			buf += decoder.decode();
+			break;
+		}
+		buf += decoder.decode(value, { stream: true });
+
+		let nl;
+		while ((nl = buf.indexOf('\n')) >= 0) {
+			const line = buf.slice(0, nl);
+			buf = buf.slice(nl + 1);
+			if (!line) continue;
+			const rec = JSON.parse(line) as NdjsonRecord;
+			if (rec.t === 'err') {
+				throw new Error(`Stream error: ${rec.message}`);
+			}
+			if (rec.t === 'end') {
+				sawEnd = true;
+				break;
+			}
+			await onRecord(rec);
+		}
+	}
+
+	if (buf.trim().length > 0) {
+		throw new Error(`Stream ended with unterminated record: ${buf.slice(0, 120)}`);
+	}
+	if (!sawEnd) {
+		throw new Error('Stream ended without {"t":"end"} marker (truncated)');
+	}
+}
+
+interface PendingFileChunk {
+	kind: 'file';
+	path: string;
+	b64: string;
+	first: boolean;
+}
+
+interface PendingSqlChunk {
+	kind: 'sql';
+	b64: string;
+}
+
+type PendingChunk = PendingFileChunk | PendingSqlChunk;
+
+/**
+ * Buffers incoming chunks and flushes them inside Playground via a single
+ * PHP run that loops `file_put_contents(..., FILE_APPEND)` per chunk.
+ *
+ * Trades a small bounded JS-side buffer (default 4 MB) for far fewer PHP
+ * round-trips than per-chunk flushing. Total memory is bounded by
+ * `flushBytes`, regardless of export size.
+ */
+export class BatchedDiskFlusher {
+	private queue: PendingChunk[] = [];
+	private queuedBytes = 0;
+	private readonly flushBytes: number;
+	private readonly client: PlaygroundClient;
+	private readonly sqlPath: string;
+
+	constructor(
+		client: PlaygroundClient,
+		options: { flushBytes?: number; sqlPath?: string } = {},
+	) {
+		this.client = client;
+		this.flushBytes = options.flushBytes ?? 4 * 1024 * 1024;
+		this.sqlPath = options.sqlPath ?? '/tmp/lse-import.sql';
+	}
+
+	getSqlPath(): string {
+		return this.sqlPath;
+	}
+
+	async addFileChunk(
+		path: string,
+		b64: string,
+		first: boolean,
+	): Promise<void> {
+		this.queue.push({ kind: 'file', path, b64, first });
+		this.queuedBytes += b64.length;
+		if (this.queuedBytes >= this.flushBytes) {
+			await this.flush();
+		}
+	}
+
+	async addSqlChunk(b64: string): Promise<void> {
+		this.queue.push({ kind: 'sql', b64 });
+		this.queuedBytes += b64.length;
+		if (this.queuedBytes >= this.flushBytes) {
+			await this.flush();
+		}
+	}
+
+	/**
+	 * Truncate the on-disk SQL file before streaming begins. Required because
+	 * `addSqlChunk` always appends.
+	 */
+	async resetSqlFile(): Promise<void> {
+		await this.client.writeFile(this.sqlPath, new Uint8Array(0));
+	}
+
+	async flush(): Promise<void> {
+		if (this.queue.length === 0) return;
+		const items = this.queue;
+		this.queue = [];
+		this.queuedBytes = 0;
+
+		const payload = JSON.stringify({ items, sqlPath: this.sqlPath });
+
+		await this.client.run({
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: payload,
+			code: `<?php
+				$raw = file_get_contents('php://input');
+				$data = json_decode($raw, true);
+				$sql_path = $data['sqlPath'];
+				foreach ($data['items'] as $it) {
+					$bytes = base64_decode($it['b64']);
+					if ($it['kind'] === 'file') {
+						$p = $it['path'];
+						if (!empty($it['first'])) {
+							@mkdir(dirname($p), 0777, true);
+							file_put_contents($p, $bytes);
+						} else {
+							file_put_contents($p, $bytes, FILE_APPEND);
+						}
+					} elseif ($it['kind'] === 'sql') {
+						file_put_contents($sql_path, $bytes, FILE_APPEND);
+					}
+				}
+			`,
+		});
+	}
+}

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,10 +1,10 @@
 import type { PlaygroundClient } from '@wp-playground/client';
 
 export type NdjsonRecord =
-	| { t: 'f'; path: string; b64: string; seq: number; final: boolean }
-	| { t: 'sql'; b64: string }
-	| { t: 'end' }
-	| { t: 'err'; message: string };
+	| { type: 'file'; path: string; b64: string; seq: number; final: boolean }
+	| { type: 'sql'; b64: string }
+	| { type: 'end' }
+	| { type: 'err'; message: string };
 
 /**
  * Read an NDJSON response body line by line, invoking `onRecord` for each
@@ -40,10 +40,10 @@ export async function readNdjson(
 			buf = buf.slice(nl + 1);
 			if (!line) continue;
 			const rec = JSON.parse(line) as NdjsonRecord;
-			if (rec.t === 'err') {
+			if (rec.type === 'err') {
 				throw new Error(`Stream error: ${rec.message}`);
 			}
-			if (rec.t === 'end') {
+			if (rec.type === 'end') {
 				sawEnd = true;
 				break;
 			}
@@ -137,29 +137,50 @@ export class BatchedDiskFlusher {
 
 		const payload = JSON.stringify({ items, sqlPath: this.sqlPath });
 
-		await this.client.run({
+		const result = await this.client.run({
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: payload,
 			code: `<?php
 				$raw = file_get_contents('php://input');
 				$data = json_decode($raw, true);
+				if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+					echo json_encode(['errors' => ['json_decode failed: ' . json_last_error_msg()]]);
+					exit;
+				}
 				$sql_path = $data['sqlPath'];
+				$errors = [];
 				foreach ($data['items'] as $it) {
-					$bytes = base64_decode($it['b64']);
+					$bytes = base64_decode($it['b64'], true);
+					if ($bytes === false) {
+						$errors[] = 'base64_decode failed for ' . $it['kind'] . ' chunk';
+						continue;
+					}
 					if ($it['kind'] === 'file') {
 						$p = $it['path'];
 						if (!empty($it['first'])) {
 							@mkdir(dirname($p), 0777, true);
-							file_put_contents($p, $bytes);
+							$written = file_put_contents($p, $bytes);
 						} else {
-							file_put_contents($p, $bytes, FILE_APPEND);
+							$written = file_put_contents($p, $bytes, FILE_APPEND);
+						}
+						if ($written === false) {
+							$errors[] = 'Failed to write file chunk to ' . $p;
 						}
 					} elseif ($it['kind'] === 'sql') {
-						file_put_contents($sql_path, $bytes, FILE_APPEND);
+						$written = file_put_contents($sql_path, $bytes, FILE_APPEND);
+						if ($written === false) {
+							$errors[] = 'Failed to append SQL chunk to ' . $sql_path;
+						}
 					}
 				}
+				echo json_encode(['errors' => $errors]);
 			`,
 		});
+
+		const response = JSON.parse(result.text) as { errors: string[] };
+		if (response.errors.length > 0) {
+			throw new Error(`Disk flush failed: ${response.errors.join('; ')}`);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Switched `/reprint-files` and `/reprint-db` from cursor-paginated JSON to NDJSON streaming. PHP exits before the WP REST dispatcher buffers a response; output buffers, gzip, and proxy buffering are explicitly disabled.
- Added `src/streaming.ts` with `readNdjson()` (line-framed parser, requires `{t:"end"}` terminator) and `BatchedDiskFlusher` (queues chunks, flushes ~4 MB batches into Playground via a single PHP `FILE_APPEND` loop).
- File chunks are written directly to Playground disk per-chunk; the SQL dump is streamed to `/tmp/lse-import.sql` and executed from disk. Neither full files nor the full SQL ever live in JS or PHP memory.
- Renamed `runSqlVerbose` → `runSqlFromDisk`; per-statement error sampling now only logs when `debugMode` is on.
- Drops `cursor` query arg, `WP_Error`/`WP_REST_Response` returns, and the JS-side `base64ToBytes` helper.

## Why
The previous design held an entire file (and the entire SQL dump) in memory on both ends, plus serialized everything through a JSON envelope. Large `wp-content` directories or DBs OOM'd or timed out. Streaming bounds peak memory to chunk size on both sides and lets long exports finish even when `max_execution_time` would otherwise kill the request.

## Test plan
- [ ] Import a site with a `wp-content` directory >100 MB, including binary assets (images, fonts) — verify byte-identical files in Playground.
- [ ] Import a DB dump large enough to exceed prior cursor-batch limits; confirm row counts match and `runSqlFromDisk` reports 0 failures.
- [ ] Mid-stream abort (close tab) — server should not error-log; `ignore_user_abort(true)` keeps it running, `connection_aborted()` exits cleanly.
- [ ] Run with `debugMode` on and a deliberately broken statement; confirm sample errors surface in the console.
- [ ] Run on a host with `zlib.output_compression` enabled to confirm `Content-Encoding: identity` defeats it.

Note: four untracked files in the working tree (`debug-rest-encoding.php`, `err.sql`, `lexer-bug-handoff.md`, `reprint-db-dump.sql`) were not included.