### PR TITLE
Switch sync to chunked stream and stream SQL import in Playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
 
       - name: Check PHP syntax
         run: |
-          find live-sandbox-editor \
+          find live-sandbox-editor src \
             -path 'live-sandbox-editor/vendor' -prune -o \
             -name '*.php' -print0 \
             | xargs -0 -n1 php -l
+
+      - name: Check PHP coding standards (src/)
+        run: composer lint:src

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,12 @@
 			"@composer install --working-dir=live-sandbox-editor --no-scripts --no-dev"
 		],
 		"post-install-cmd": ["@install-plugin-vendor"],
-		"post-update-cmd": ["@install-plugin-vendor"]
+		"post-update-cmd": ["@install-plugin-vendor"],
+		"lint:src": "phpcs --standard=phpcs.xml src/"
 	},
 	"scripts-descriptions": {
-		"install-plugin-vendor": "Install the live-sandbox-editor plugin's runtime dependencies (from live-sandbox-editor/plugin-composer.json) into live-sandbox-editor/vendor/. Runs automatically after every composer install/update at the repo root."
+		"install-plugin-vendor": "Install the live-sandbox-editor plugin's runtime dependencies (from live-sandbox-editor/plugin-composer.json) into live-sandbox-editor/vendor/. Runs automatically after every composer install/update at the repo root.",
+		"lint:src": "Run phpcs against src/ only (the Playground-bundled PHP library). Mirrors the CI step; leaves plugin code untouched."
 	},
 	"config": {
 		"allow-plugins": {

--- a/live-sandbox-editor/inc/manifest.php
+++ b/live-sandbox-editor/inc/manifest.php
@@ -102,7 +102,6 @@ function default_structural_tables(): array {
  * @return array{plugins:array<string>,themes:array<string>,tables:array<string>,uploads:bool}
  */
 function normalize( $raw ): array {
-	$base = defaults();
 	if ( ! is_array( $raw ) ) {
 		return array(
 			'plugins' => array(),

--- a/live-sandbox-editor/inc/manifest.php
+++ b/live-sandbox-editor/inc/manifest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Sync manifest helpers.
+ *
+ * Manifest shape:
+ *   {
+ *     "plugins": [ "akismet/akismet.php", "hello.php" ],
+ *     "themes":  [ "twentytwentyfour", "twentytwentyfour-child" ],
+ *     "tables":  [ "wp_posts", "wp_options", … ],   // prefixed
+ *     "uploads": false
+ *   }
+ *
+ * - `plugins` entries are WordPress plugin entry strings (`folder/main.php`
+ *   for multi-file plugins, `single.php` for single-file plugins) — same
+ *   shape as `get_option('active_plugins')`.
+ * - `themes` are stylesheet/template slugs.
+ * - `tables` are fully prefixed table names.
+ * - `uploads` toggles syncing of `wp-content/uploads`. Default false; media
+ *   URLs are rewritten to point back at the host site post-import.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor\Manifest;
+
+/**
+ * Default manifest: active plugins, active theme + parent, structural (core
+ * WP) tables, no uploads.
+ *
+ * @return array{plugins:array<string>,themes:array<string>,tables:array<string>,uploads:bool}
+ */
+function defaults(): array {
+	return array(
+		'plugins' => default_active_plugins(),
+		'themes'  => default_active_themes(),
+		'tables'  => default_structural_tables(),
+		'uploads' => false,
+	);
+}
+
+/**
+ * Active plugin entries. On multisite, includes network-active plugins.
+ * Self plugin (live-sandbox-editor) is always excluded — we don't want
+ * the sandbox to load the editor that booted it.
+ *
+ * @return array<string>
+ */
+function default_active_plugins(): array {
+	$active = (array) get_option( 'active_plugins', array() );
+	if ( is_multisite() ) {
+		$network = (array) get_site_option( 'active_sitewide_plugins', array() );
+		$active  = array_merge( $active, array_keys( $network ) );
+	}
+	$active = array_values(
+		array_unique(
+			array_filter(
+				$active,
+				static fn( $entry ) => is_string( $entry ) && '' !== $entry && ! is_self_plugin_entry( $entry )
+			)
+		)
+	);
+	return $active;
+}
+
+/**
+ * Active stylesheet plus its template, if different. Both are returned so
+ * a child theme + its parent are synced together by default.
+ *
+ * @return array<string>
+ */
+function default_active_themes(): array {
+	$slugs      = array();
+	$stylesheet = (string) get_stylesheet();
+	$template   = (string) get_template();
+	if ( '' !== $stylesheet ) {
+		$slugs[] = $stylesheet;
+	}
+	if ( '' !== $template && $template !== $stylesheet ) {
+		$slugs[] = $template;
+	}
+	return $slugs;
+}
+
+/**
+ * Core WordPress tables (prefixed). Plugin/custom tables are excluded.
+ *
+ * @return array<string>
+ */
+function default_structural_tables(): array {
+	global $wpdb;
+	$blog   = (array) $wpdb->tables( 'blog', true );
+	$global = is_multisite() ? (array) $wpdb->tables( 'global', true ) : array();
+	return array_values( array_unique( array_merge( array_values( $blog ), array_values( $global ) ) ) );
+}
+
+/**
+ * Coerce a decoded JSON manifest into the canonical shape used by the
+ * sync endpoints. Drops unknown keys, validates types, and falls back
+ * to empty arrays / `false` for malformed input.
+ *
+ * @param mixed $raw Decoded JSON manifest (or null/array from request).
+ * @return array{plugins:array<string>,themes:array<string>,tables:array<string>,uploads:bool}
+ */
+function normalize( $raw ): array {
+	$base = defaults();
+	if ( ! is_array( $raw ) ) {
+		return array(
+			'plugins' => array(),
+			'themes'  => array(),
+			'tables'  => array(),
+			'uploads' => false,
+		);
+	}
+
+	$plugins = array();
+	if ( isset( $raw['plugins'] ) && is_array( $raw['plugins'] ) ) {
+		foreach ( $raw['plugins'] as $entry ) {
+			if ( is_string( $entry ) && '' !== $entry && ! is_self_plugin_entry( $entry ) ) {
+				$plugins[] = $entry;
+			}
+		}
+	}
+
+	$themes = array();
+	if ( isset( $raw['themes'] ) && is_array( $raw['themes'] ) ) {
+		foreach ( $raw['themes'] as $slug ) {
+			if ( is_string( $slug ) && '' !== $slug ) {
+				$themes[] = $slug;
+			}
+		}
+	}
+
+	$tables = array();
+	if ( isset( $raw['tables'] ) && is_array( $raw['tables'] ) ) {
+		global $wpdb;
+		$prefix = (string) $wpdb->prefix;
+		$base_p = (string) $wpdb->base_prefix;
+		foreach ( $raw['tables'] as $name ) {
+			if ( ! is_string( $name ) || '' === $name ) {
+				continue;
+			}
+			// Defence in depth: only allow safe table-name characters and
+			// require the configured prefix so we never dump arbitrary tables.
+			if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $name ) ) {
+				continue;
+			}
+			if ( ! str_starts_with( $name, $prefix ) && ! str_starts_with( $name, $base_p ) ) {
+				continue;
+			}
+			$tables[] = $name;
+		}
+	}
+
+	$uploads = ! empty( $raw['uploads'] );
+
+	return array(
+		'plugins' => array_values( array_unique( $plugins ) ),
+		'themes'  => array_values( array_unique( $themes ) ),
+		'tables'  => array_values( array_unique( $tables ) ),
+		'uploads' => $uploads,
+	);
+}
+
+/**
+ * Resolve a plugin entry to absolute host paths plus a logical
+ * Playground-relative path for each file. Handles single-file plugins.
+ *
+ * Returned tuples:
+ *   [ host_abs_path, logical_path ]  where logical_path begins '/wp-content/plugins/...'
+ *
+ * @param string $entry Plugin entry (folder/main.php or single.php).
+ * @return array<int,array{0:string,1:string}>
+ */
+function plugin_paths( string $entry ): array {
+	$plugin_dir   = rtrim( WP_PLUGIN_DIR, '/' );
+	$logical_root = '/wp-content/plugins';
+
+	if ( str_contains( $entry, '/' ) ) {
+		$slug         = explode( '/', $entry, 2 )[0];
+		$host_root    = $plugin_dir . '/' . $slug;
+		$logical_base = $logical_root . '/' . $slug;
+		return collect_files( $host_root, $logical_base );
+	}
+
+	// Single-file plugin lives directly in the plugins dir.
+	$host_path = $plugin_dir . '/' . $entry;
+	if ( ! is_file( $host_path ) ) {
+		return array();
+	}
+	return array( array( $host_path, $logical_root . '/' . $entry ) );
+}
+
+/**
+ * Resolve a theme slug to its host directory and logical Playground path.
+ * Uses get_theme_root() so registered alternate theme roots work.
+ *
+ * @param string $slug Theme slug.
+ * @return array<int,array{0:string,1:string}>
+ */
+function theme_paths( string $slug ): array {
+	$theme_root = (string) get_theme_root( $slug );
+	if ( '' === $theme_root ) {
+		return array();
+	}
+	$host_root    = rtrim( $theme_root, '/' ) . '/' . $slug;
+	$logical_base = '/wp-content/themes/' . $slug;
+	return collect_files( $host_root, $logical_base );
+}
+
+/**
+ * Resolve uploads dir.
+ *
+ * @return array<int,array{0:string,1:string}>
+ */
+function uploads_paths(): array {
+	$dirs = wp_upload_dir( null, false );
+	if ( empty( $dirs['basedir'] ) ) {
+		return array();
+	}
+	return collect_files( rtrim( $dirs['basedir'], '/' ), '/wp-content/uploads' );
+}
+
+/**
+ * Walk a directory and return [host_abs, logical] tuples for every regular
+ * file, skipping the self-plugin directory anywhere in the tree.
+ *
+ * @param string $host_root    Absolute host path to walk.
+ * @param string $logical_base Logical path prefix used in the wire stream.
+ * @return array<int,array{0:string,1:string}>
+ */
+function collect_files( string $host_root, string $logical_base ): array {
+	if ( ! is_dir( $host_root ) ) {
+		return array();
+	}
+	$self_plugin = self_plugin_dir();
+	$out         = array();
+	try {
+		$rdi      = new \RecursiveDirectoryIterator(
+			$host_root,
+			\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::CURRENT_AS_FILEINFO
+		);
+		$filtered = new \RecursiveCallbackFilterIterator(
+			$rdi,
+			static function ( \SplFileInfo $current ) use ( $self_plugin ): bool {
+				if ( null === $self_plugin ) {
+					return true;
+				}
+				$real = $current->getRealPath();
+				if ( false === $real ) {
+					return true;
+				}
+				return $real !== $self_plugin
+					&& ! str_starts_with( $real, $self_plugin . DIRECTORY_SEPARATOR );
+			}
+		);
+		$rii      = new \RecursiveIteratorIterator( $filtered, \RecursiveIteratorIterator::SELF_FIRST );
+		$root_len = strlen( $host_root );
+		foreach ( $rii as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+			$abs     = $file->getPathname();
+			$rel     = substr( $abs, $root_len );
+			$logical = $logical_base . str_replace( DIRECTORY_SEPARATOR, '/', $rel );
+			$out[]   = array( $abs, $logical );
+		}
+	} catch ( \UnexpectedValueException $e ) {
+		// Unreadable directory — silently skip; the stream still finishes.
+		return $out;
+	}
+	return $out;
+}
+
+/**
+ * Absolute path of this plugin's own directory, or null if it cannot be
+ * resolved. Used to keep the editor itself out of synced filesets.
+ */
+function self_plugin_dir(): ?string {
+	$dir = realpath( dirname( __DIR__ ) );
+	return false === $dir ? null : $dir;
+}
+
+/**
+ * Match $entry against this plugin's main file by postfix.
+ *
+ * Directory names aren't stable across installs (users may rename or
+ * symlink), so the comparison anchors on the main filename.
+ *
+ * @param string $entry Plugin entry as stored in `active_plugins`.
+ * @return bool
+ */
+function is_self_plugin_entry( string $entry ): bool {
+	return str_ends_with( $entry, '/live-sandbox-editor.php' )
+		|| 'live-sandbox-editor.php' === $entry;
+}
+
+/**
+ * Decode the manifest from a REST request — supports both a `manifest`
+ * JSON string param and a raw JSON body.
+ *
+ * @param \WP_REST_Request $request Request.
+ * @return array{plugins:array<string>,themes:array<string>,tables:array<string>,uploads:bool}
+ */
+function from_request( \WP_REST_Request $request ): array {
+	$param = $request->get_param( 'manifest' );
+	if ( is_string( $param ) && '' !== $param ) {
+		$decoded = json_decode( $param, true );
+		if ( is_array( $decoded ) ) {
+			return normalize( $decoded );
+		}
+	}
+	$body = $request->get_json_params();
+	if ( is_array( $body ) ) {
+		return normalize( $body );
+	}
+	return normalize( null );
+}

--- a/live-sandbox-editor/inc/manifest.php
+++ b/live-sandbox-editor/inc/manifest.php
@@ -114,7 +114,7 @@ function normalize( $raw ): array {
 	$plugins = array();
 	if ( isset( $raw['plugins'] ) && is_array( $raw['plugins'] ) ) {
 		foreach ( $raw['plugins'] as $entry ) {
-			if ( is_string( $entry ) && '' !== $entry && ! is_self_plugin_entry( $entry ) ) {
+			if ( is_string( $entry ) && '' !== $entry && is_safe_plugin_entry( $entry ) && ! is_self_plugin_entry( $entry ) ) {
 				$plugins[] = $entry;
 			}
 		}
@@ -123,7 +123,7 @@ function normalize( $raw ): array {
 	$themes = array();
 	if ( isset( $raw['themes'] ) && is_array( $raw['themes'] ) ) {
 		foreach ( $raw['themes'] as $slug ) {
-			if ( is_string( $slug ) && '' !== $slug ) {
+			if ( is_string( $slug ) && '' !== $slug && is_safe_theme_slug( $slug ) ) {
 				$themes[] = $slug;
 			}
 		}
@@ -171,22 +171,47 @@ function normalize( $raw ): array {
  * @return array<int,array{0:string,1:string}>
  */
 function plugin_paths( string $entry ): array {
-	$plugin_dir   = rtrim( WP_PLUGIN_DIR, '/' );
+	$plugin_dir_real = realpath( WP_PLUGIN_DIR );
+	if ( false === $plugin_dir_real ) {
+		return array();
+	}
+
+	$plugin_dir   = rtrim( $plugin_dir_real, '/\\' );
 	$logical_root = '/wp-content/plugins';
 
 	if ( str_contains( $entry, '/' ) ) {
-		$slug         = explode( '/', $entry, 2 )[0];
-		$host_root    = $plugin_dir . '/' . $slug;
+		$slug              = explode( '/', $entry, 2 )[0];
+		$host_root         = $plugin_dir . '/' . $slug;
+		$host_root_real    = realpath( $host_root );
+		$plugin_dir_prefix = $plugin_dir . '/';
+
+		if (
+			false === $host_root_real ||
+			! is_dir( $host_root_real ) ||
+			$host_root_real !== $plugin_dir &&
+			0 !== strpos( $host_root_real, $plugin_dir_prefix )
+		) {
+			return array();
+		}
+
 		$logical_base = $logical_root . '/' . $slug;
-		return collect_files( $host_root, $logical_base );
+		return collect_files( $host_root_real, $logical_base );
 	}
 
 	// Single-file plugin lives directly in the plugins dir.
-	$host_path = $plugin_dir . '/' . $entry;
-	if ( ! is_file( $host_path ) ) {
+	$host_path         = $plugin_dir . '/' . $entry;
+	$host_path_real    = realpath( $host_path );
+	$plugin_dir_prefix = $plugin_dir . '/';
+
+	if (
+		false === $host_path_real ||
+		! is_file( $host_path_real ) ||
+		0 !== strpos( $host_path_real, $plugin_dir_prefix )
+	) {
 		return array();
 	}
-	return array( array( $host_path, $logical_root . '/' . $entry ) );
+
+	return array( array( $host_path_real, $logical_root . '/' . $entry ) );
 }
 
 /**
@@ -291,6 +316,41 @@ function self_plugin_dir(): ?string {
 function is_self_plugin_entry( string $entry ): bool {
 	return str_ends_with( $entry, '/live-sandbox-editor.php' )
 		|| 'live-sandbox-editor.php' === $entry;
+}
+
+/**
+ * Allowlist a plugin entry against the two shapes WordPress uses:
+ * `slug/main.php` or `single.php`. Rejects path traversal (`..`),
+ * empty/dot segments, and anything outside the safe charset.
+ *
+ * @param string $entry Plugin entry from a manifest.
+ * @return bool
+ */
+function is_safe_plugin_entry( string $entry ): bool {
+	if ( ! preg_match( '#^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?\.php$#', $entry ) ) {
+		return false;
+	}
+	foreach ( explode( '/', $entry ) as $segment ) {
+		if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Allowlist a theme slug. Themes are a single path segment under the
+ * theme root, so the same character class as plugins applies but
+ * without a `/`.
+ *
+ * @param string $slug Theme slug from a manifest.
+ * @return bool
+ */
+function is_safe_theme_slug( string $slug ): bool {
+	if ( ! preg_match( '/^[A-Za-z0-9._-]+$/', $slug ) ) {
+		return false;
+	}
+	return '.' !== $slug && '..' !== $slug;
 }
 
 /**

--- a/live-sandbox-editor/inc/sync-stream.php
+++ b/live-sandbox-editor/inc/sync-stream.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Wire format for chunked sync streams.
+ *
+ * Stream is text (ASCII) interleaving sentinel markers with base64 payload.
+ * Markers begin with `\n#LSE:` — characters that cannot appear in base64
+ * output, so the receiver can scan unambiguously without escaping.
+ *
+ *   \n#LSE:FILE:<urlencoded path>\n   start a file record
+ *   \n#LSE:SQL\n                       start a SQL record
+ *   \n#LSE:END\n                       end of current record
+ *   \n#LSE:DONE\n                      end of stream
+ *   \n#LSE:ERR:<urlencoded msg>\n      fatal error (terminal)
+ *
+ * Payload between START and END is one continuous base64-encoded byte
+ * stream. To allow streaming concatenation, the producer encodes only
+ * 3-byte-aligned prefixes mid-record and emits the (padded) tail on END;
+ * the receiver can therefore decode 4-char-aligned chunks as they arrive.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor\Sync_Stream;
+
+const MARKER_FILE = 'FILE';
+const MARKER_SQL  = 'SQL';
+const MARKER_END  = 'END';
+const MARKER_DONE = 'DONE';
+const MARKER_ERR  = 'ERR';
+
+/**
+ * Disable buffering, compression and timeouts so the body is streamed
+ * unmodified. Mirrors the previous NDJSON setup.
+ */
+function setup(): void {
+	while ( ob_get_level() > 0 ) {
+		ob_end_clean();
+	}
+	// phpcs:ignore WordPress.PHP.IniSet.Risky,WordPress.PHP.NoSilencedErrors.Discouraged -- intentional: streaming response, output buffering / compression must be off; ini_set may be disabled on some hosts.
+	@ini_set( 'zlib.output_compression', '0' );
+	if ( function_exists( 'apache_setenv' ) ) {
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_apache_setenv -- intentional: streaming response, gzip must be off; apache_setenv is the only way to force this on mod_php.
+		@apache_setenv( 'no-gzip', '1' );
+	}
+	// Streaming a full export comfortably exceeds the default 30s
+	// max_execution_time. Disable up front and reset periodically — some
+	// hosts silently re-impose a per-iteration timer.
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
+	@set_time_limit( 0 );
+	ignore_user_abort( true );
+	if ( function_exists( 'session_write_close' ) ) {
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- harmless if no session is active.
+		@session_write_close();
+	}
+	nocache_headers();
+	header( 'Content-Type: application/octet-stream' );
+	header( 'Cache-Control: no-cache, no-store, no-transform, must-revalidate' );
+	header( 'Pragma: no-cache' );
+	header( 'X-Accel-Buffering: no' );
+	header( 'Content-Encoding: identity' );
+	header( 'X-Content-Type-Options: nosniff' );
+}
+
+/**
+ * Emit a sentinel marker line.
+ *
+ * @param string      $name Marker name (one of the MARKER_* constants).
+ * @param string|null $arg  Optional argument. URL-encoded so newlines/colons can't break framing.
+ */
+function emit_marker( string $name, ?string $arg = null ): void {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $name comes from MARKER_* constants; protocol is binary stream, not HTML.
+	echo "\n#LSE:", $name;
+	if ( null !== $arg ) {
+		echo ':', rawurlencode( $arg );
+	}
+	echo "\n";
+	flush();
+}
+
+/**
+ * Streaming base64 encoder — buffers up to 2 unaligned bytes between calls
+ * so concatenated output remains valid base64 (no mid-stream `=` padding).
+ *
+ * Usage:
+ *   $b = new B64_Streamer();
+ *   $b->feed($bytes_a);
+ *   $b->feed($bytes_b);
+ *   $b->finalize(); // flushes the remaining 1–2 bytes with padding
+ */
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- the streamer is the back end of the procedural emit_marker() above; same wire format, kept in one file for locality.
+
+/**
+ * Streaming base64 encoder. See file header for the full wire-format
+ * contract; this class implements the per-record encoding side.
+ */
+final class B64_Streamer {
+	/**
+	 * Buffered tail of unaligned bytes from the previous `feed()` call.
+	 *
+	 * Up to 2 bytes that didn't fit a 3-byte base64 group are held here
+	 * and prepended to the next chunk so the encoded stream stays valid
+	 * with no mid-stream padding.
+	 *
+	 * @var string
+	 */
+	private string $tail = '';
+
+	/**
+	 * Append $bytes to the stream. Encodes 3-byte-aligned prefixes,
+	 * buffers the remainder for the next call.
+	 *
+	 * @param string $bytes Raw bytes to encode.
+	 */
+	public function feed( string $bytes ): void {
+		if ( '' === $bytes ) {
+			return;
+		}
+		$buf = $this->tail . $bytes;
+		$len = strlen( $buf );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.math_intdiv
+		$aligned    = intdiv( $len, 3 ) * 3;
+		$this->tail = (string) substr( $buf, $aligned );
+		if ( $aligned > 0 ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode,WordPress.Security.EscapeOutput.OutputNotEscaped -- binary protocol, not HTML; base64 output is the intended wire format.
+			echo base64_encode( substr( $buf, 0, $aligned ) );
+		}
+	}
+
+	/**
+	 * Flush the trailing 1–2 bytes (with padding) and the underlying
+	 * output buffer.
+	 */
+	public function finalize(): void {
+		if ( '' !== $this->tail ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode,WordPress.Security.EscapeOutput.OutputNotEscaped -- see feed().
+			echo base64_encode( $this->tail );
+			$this->tail = '';
+		}
+		flush();
+	}
+}

--- a/live-sandbox-editor/inc/sync-stream.php
+++ b/live-sandbox-editor/inc/sync-stream.php
@@ -30,7 +30,7 @@ const MARKER_ERR  = 'ERR';
 
 /**
  * Disable buffering, compression and timeouts so the body is streamed
- * unmodified. Mirrors the previous NDJSON setup.
+ * unmodified.
  */
 function setup(): void {
 	while ( ob_get_level() > 0 ) {

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -17,16 +17,14 @@
 namespace Live_Sandbox_Editor;
 
 use FileTreeProducer;
-use RecursiveCallbackFilterIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use WP_Error;
-use SplFileInfo;
 use WP_REST_Request;
 use WordPress\DataLiberation\MySQLDumpProducer;
 
 const SLUG    = 'live-sandbox-editor';
 const VERSION = '0.1';
+
+require_once __DIR__ . '/inc/sync-stream.php';
+require_once __DIR__ . '/inc/manifest.php';
 
 /**
  * Load vendored Reprint classes only if they are not already defined.
@@ -164,242 +162,247 @@ function reprint_notice(): void {
 
 /** Register REST API routes. */
 function register_rest_routes(): void {
+	$can_manage = static fn() => current_user_can( 'manage_options' );
+
 	register_rest_route(
 		SLUG . '/v1',
-		'/reprint-files',
+		'/sync-manifest',
 		array(
 			'methods'             => 'GET',
-			'permission_callback' => fn() => current_user_can( 'manage_options' ),
-			'callback'            => __NAMESPACE__ . '\\rest_reprint_files',
+			'permission_callback' => $can_manage,
+			'callback'            => __NAMESPACE__ . '\\rest_sync_manifest',
 		)
 	);
 
 	register_rest_route(
 		SLUG . '/v1',
-		'/reprint-db',
+		'/sync-files',
 		array(
-			'methods'             => 'GET',
-			'permission_callback' => fn() => current_user_can( 'manage_options' ),
-			'callback'            => __NAMESPACE__ . '\\rest_reprint_db',
+			'methods'             => array( 'GET', 'POST' ),
+			'permission_callback' => $can_manage,
+			'callback'            => __NAMESPACE__ . '\\rest_sync_files',
+		)
+	);
+
+	register_rest_route(
+		SLUG . '/v1',
+		'/sync-db',
+		array(
+			'methods'             => array( 'GET', 'POST' ),
+			'permission_callback' => $can_manage,
+			'callback'            => __NAMESPACE__ . '\\rest_sync_db',
 		)
 	);
 }
 
 /**
- * Prepare a streaming NDJSON response: drop output buffers, disable
- * compression/buffering middleware, send the header set, and return.
- *
- * Caller is responsible for echoing one JSON object per line (terminated
- * with "\n"), calling flush() after each, and exiting before the WP REST
- * dispatcher tries to wrap a return value.
- */
-function stream_ndjson_setup(): void {
-	while ( ob_get_level() > 0 ) {
-		ob_end_clean();
-	}
-	@ini_set( 'zlib.output_compression', '0' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
-	if ( function_exists( 'apache_setenv' ) ) {
-		@apache_setenv( 'no-gzip', '1' );
-	}
-	// Streaming a full wp-content / DB dump comfortably exceeds the default
-	// 30s max_execution_time. Disable it for this request and call
-	// set_time_limit() again periodically inside the loop in case the host
-	// silently re-imposes a per-iteration timer.
-	@set_time_limit( 0 );
-	// Keep producing data even if the browser tab closes — half-written files
-	// in Playground are useless, so we'd rather finish the stream.
-	ignore_user_abort( true );
-	if ( function_exists( 'session_write_close' ) ) {
-		@session_write_close();
-	}
-	nocache_headers();
-	header( 'Content-Type: application/x-ndjson; charset=utf-8' );
-	header( 'Cache-Control: no-cache, no-store, no-transform, must-revalidate' );
-	header( 'Pragma: no-cache' );
-	// nginx: opt this response out of proxy_buffering.
-	header( 'X-Accel-Buffering: no' );
-	// Defeat compression middleware that otherwise buffers entire body.
-	header( 'Content-Encoding: identity' );
-	header( 'X-Content-Type-Options: nosniff' );
-	// Deliberately no Content-Length — its absence forces chunked transfer.
-}
-
-/**
- * Emit a single NDJSON record and flush.
- *
- * @param array $record Record payload — JSON-encoded as one line.
- */
-function stream_ndjson_emit( array $record ): void {
-	echo wp_json_encode( $record, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS ), "\n";
-	flush();
-}
-
-/**
- * REST callback: stream wp-content files as NDJSON.
- *
- * Each line is one chunk of one file:
- *   { "type":"file", "path":"/wp-content/…", "b64":"…", "seq":N, "final":bool }
- *
- * The handler bypasses WP_REST_Response and exits directly so the body is
- * streamed without WP's JSON-envelope buffering. PHP peak memory stays
- * bounded by chunk size (no per-file accumulation, no response array).
+ * REST callback: return the default sync manifest plus the host site URL
+ * and uploads URL, so the JS side can decide how to drive the sync and
+ * how to rewrite media URLs after import.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  *
  * @param  WP_REST_Request $request Request.
- * @return WP_Error|void
+ * @return array
  */
-function rest_reprint_files( WP_REST_Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function rest_sync_manifest( WP_REST_Request $request ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	$uploads     = wp_upload_dir( null, false );
+	$uploads_url = is_array( $uploads ) && ! empty( $uploads['baseurl'] ) ? (string) $uploads['baseurl'] : '';
+	return array(
+		'manifest'   => Manifest\defaults(),
+		'siteUrl'    => (string) get_site_url(),
+		'uploadsUrl' => $uploads_url,
+	);
+}
+
+/**
+ * REST callback: stream selected files using the chunked-terminator wire
+ * format. The handler exits directly so the body is streamed without WP's
+ * JSON-envelope buffering.
+ *
+ * @param  WP_REST_Request $request Request.
+ */
+function rest_sync_files( WP_REST_Request $request ): void {
 	maybe_load_reprint();
+	Sync_Stream\setup();
 
 	if ( ! class_exists( 'FileTreeProducer' ) ) {
-		http_response_code( 500 );
-		stream_ndjson_setup();
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'Reprint classes not available.' ) );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'Reprint classes not available.' );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
-	$wp_content_dir = rtrim( WP_CONTENT_DIR, '/' );
+	$manifest = Manifest\from_request( $request );
 
-	// realpath so the comparison survives symlinked plugin installs.
-	$plugin_dir = realpath( __DIR__ );
-	if ( false === $plugin_dir ) {
-		return new WP_Error( 'plugin_path_unresolved', 'Could not resolve plugin directory.', array( 'status' => 500 ) );
-	}
-
-	// Build the full path list that FileTreeProducer requires on every request.
-	// Directory iteration is fast; the producer handles cursor-based positioning.
-	$paths = array();
-	try {
-		$rdi      = new RecursiveDirectoryIterator( $wp_content_dir, RecursiveDirectoryIterator::SKIP_DOTS );
-		$filtered = new RecursiveCallbackFilterIterator(
-			$rdi,
-			static function ( SplFileInfo $current ) use ( $plugin_dir ): bool {
-				$path = $current->getRealPath();
-
-				if ( false === $path ) {
-					return true;
-				}
-
-				return $path !== $plugin_dir
-					&& ! str_starts_with( $path, $plugin_dir . DIRECTORY_SEPARATOR );
-			}
-		);
-		$rii      = new RecursiveIteratorIterator( $filtered, RecursiveIteratorIterator::SELF_FIRST );
-		foreach ( $rii as $file ) {
-			$paths[] = $file->getPathname();
-		}
-	} catch ( \UnexpectedValueException $e ) {
-		http_response_code( 500 );
-		stream_ndjson_setup();
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'scan_error: ' . $e->getMessage() ) );
+	$entries = build_file_entries( $manifest );
+	if ( empty( $entries ) ) {
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
-	stream_ndjson_setup();
+	$paths       = array();
+	$logical_for = array();
+	foreach ( $entries as $tuple ) {
+		$paths[]                  = $tuple[0];
+		$logical_for[ $tuple[0] ] = $tuple[1];
+	}
 
-	// Small chunks keep PHP peak memory bounded regardless of file size; the
-	// underlying FileTreeProducer reads files in $chunk_size pieces.
+	// FileTreeProducer's `directories` argument is normalised but not
+	// enforced against `paths`; passing a sentinel value is fine.
 	$producer = new FileTreeProducer(
-		$wp_content_dir,
+		'/',
 		array(
 			'paths'      => $paths,
 			'chunk_size' => 256 * 1024,
 		)
 	);
 
-	$content_prefix_len = strlen( $wp_content_dir );
-	$emitted            = 0;
+	$encoder      = new Sync_Stream\B64_Streamer();
+	$emitted      = 0;
+	$current_path = null;
 
 	try {
 		while ( $producer->next_chunk() ) {
 			$chunk = $producer->get_current_chunk();
-			if ( ! $chunk || $chunk['type'] !== 'file' ) {
+			if ( ! $chunk || 'file' !== $chunk['type'] ) {
 				continue;
 			}
 
-			$rel = '/wp-content' . substr( $chunk['path'], $content_prefix_len );
+			$host_path = $chunk['path'];
+			$logical   = $logical_for[ $host_path ] ?? null;
+			if ( null === $logical ) {
+				continue;
+			}
 
-			stream_ndjson_emit(
-				array(
-					'type'  => 'file',
-					'path'  => $rel,
-					'b64'   => base64_encode( $chunk['data'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-					'seq'   => (int) ( $chunk['offset'] ?? 0 ),
-					'final' => (bool) ( $chunk['is_last_chunk'] ?? false ),
-				)
-			);
+			if ( $current_path !== $logical ) {
+				if ( null !== $current_path ) {
+					$encoder->finalize();
+					Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
+				}
+				Sync_Stream\emit_marker( Sync_Stream\MARKER_FILE, $logical );
+				$current_path = $logical;
+			}
 
-			// Reset the wall-clock budget every so often: some hosts reapply
-			// max_execution_time after each request hook even when we set 0
-			// up front, and the loop can run for minutes on big sites.
-			if ( ( ++$emitted % 64 ) === 0 ) {
+			$encoder->feed( $chunk['data'] );
+
+			if ( ! empty( $chunk['is_last_chunk'] ) ) {
+				$encoder->finalize();
+				Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
+				$current_path = null;
+			}
+
+			++$emitted;
+			if ( 0 === ( $emitted % 64 ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
 				@set_time_limit( 0 );
 				if ( connection_aborted() ) {
 					exit;
 				}
 			}
 		}
+
+		if ( null !== $current_path ) {
+			$encoder->finalize();
+			Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
+		}
 	} catch ( \Throwable $e ) {
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => $e->getMessage() ) );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, $e->getMessage() );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
-	stream_ndjson_emit( array( 'type' => 'end' ) );
+	Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 	exit;
 }
 
 /**
- * REST callback: stream a MySQL dump as NDJSON.
+ * Build the (host_path, logical_path) tuples to stream from a manifest.
  *
- * Each line is one SQL fragment from MySQLDumpProducer:
- *   { "type":"sql", "b64":"…" }
- *
- * Fragments are base64-encoded so embedded newlines/binary bytes don't
- * break NDJSON line framing. PHP peak memory stays bounded by the
- * largest single fragment (~max_allowed_packet).
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @param array{plugins:array<string>,themes:array<string>,uploads:bool} $manifest Normalized manifest.
+ * @return array<int,array{0:string,1:string}>
+ */
+function build_file_entries( array $manifest ): array {
+	$tuples = array();
+	foreach ( $manifest['plugins'] as $entry ) {
+		foreach ( Manifest\plugin_paths( $entry ) as $tuple ) {
+			$tuples[] = $tuple;
+		}
+	}
+	foreach ( $manifest['themes'] as $slug ) {
+		foreach ( Manifest\theme_paths( $slug ) as $tuple ) {
+			$tuples[] = $tuple;
+		}
+	}
+	if ( ! empty( $manifest['uploads'] ) ) {
+		foreach ( Manifest\uploads_paths() as $tuple ) {
+			$tuples[] = $tuple;
+		}
+	}
+
+	// Dedupe on host path — different manifest entries shouldn't double-emit a file.
+	$seen = array();
+	$out  = array();
+	foreach ( $tuples as $t ) {
+		if ( isset( $seen[ $t[0] ] ) ) {
+			continue;
+		}
+		$seen[ $t[0] ] = true;
+		$out[]         = $t;
+	}
+	return $out;
+}
+
+/**
+ * REST callback: stream a MySQL dump of the manifest's tables using the
+ * chunked-terminator wire format.
  *
  * @param  WP_REST_Request $request Request.
  */
-function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function rest_sync_db( WP_REST_Request $request ): void {
 	maybe_load_reprint();
+	Sync_Stream\setup();
 
 	if ( ! class_exists( 'WordPress\\DataLiberation\\MySQLDumpProducer' ) ) {
-		http_response_code( 503 );
-		stream_ndjson_setup();
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'Reprint classes not available.' ) );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'Reprint classes not available.' );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
+		exit;
+	}
+
+	$manifest = Manifest\from_request( $request );
+	if ( empty( $manifest['tables'] ) ) {
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
 	try {
-		// build_pdo_dsn() is provided by vendor/wp-php-toolkit/reprint-exporter/src/utils.php
-		// via Composer's `files` autoload entry; unavailable to static analysers.
+		// build_pdo_dsn() is provided by reprint-exporter's Composer `files`
+		// autoload; static analysers can't see it.
 		if ( function_exists( 'build_pdo_dsn' ) ) {
 			$dsn = build_pdo_dsn( DB_HOST, DB_NAME );
 		} else {
 			$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
 		}
-		// phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
+		// phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO -- $wpdb can't enumerate tables for the dumper; raw PDO is intentional here.
 		$pdo = new \PDO(
 			$dsn,
 			DB_USER,
 			DB_PASSWORD,
-			// phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
 			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
 		);
+		// phpcs:enable WordPress.DB.RestrictedClasses.mysql__PDO
 	} catch ( \PDOException $e ) {
-		http_response_code( 500 );
-		stream_ndjson_setup();
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => 'db_connect: ' . $e->getMessage() ) );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'db_connect: ' . $e->getMessage() );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
-	stream_ndjson_setup();
-
-	$producer = new MySQLDumpProducer( $pdo );
+	$producer = new MySQLDumpProducer(
+		$pdo,
+		array( 'tables_to_process' => $manifest['tables'] )
+	);
+	$encoder  = new Sync_Stream\B64_Streamer();
 	$emitted  = 0;
+	$started  = false;
 
 	try {
 		while ( $producer->next_sql_fragment() ) {
@@ -407,26 +410,34 @@ function rest_reprint_db( WP_REST_Request $request ): void { // phpcs:ignore Gen
 			if ( null === $fragment ) {
 				continue;
 			}
-			stream_ndjson_emit(
-				array(
-					'type' => 'sql',
-					'b64'  => base64_encode( $fragment . "\n" ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-				)
-			);
+			if ( ! $started ) {
+				Sync_Stream\emit_marker( Sync_Stream\MARKER_SQL );
+				$started = true;
+			}
+			// Newline keeps the splitter inside Playground happy: each
+			// fragment is a complete statement and trails a newline.
+			$encoder->feed( $fragment . "\n" );
 
-			if ( ( ++$emitted % 64 ) === 0 ) {
+			++$emitted;
+			if ( 0 === ( $emitted % 64 ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
 				@set_time_limit( 0 );
 				if ( connection_aborted() ) {
 					exit;
 				}
 			}
 		}
+		if ( $started ) {
+			$encoder->finalize();
+			Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
+		}
 	} catch ( \Throwable $e ) {
-		stream_ndjson_emit( array( 'type' => 'err', 'message' => $e->getMessage() ) );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, $e->getMessage() );
+		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
 	}
 
-	stream_ndjson_emit( array( 'type' => 'end' ) );
+	Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 	exit;
 }
 

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -227,6 +227,7 @@ function rest_sync_files( WP_REST_Request $request ): void {
 	Sync_Stream\setup();
 
 	if ( ! class_exists( 'FileTreeProducer' ) ) {
+		http_response_code( 500 );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'Reprint classes not available.' );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
@@ -306,6 +307,9 @@ function rest_sync_files( WP_REST_Request $request ): void {
 			Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
 		}
 	} catch ( \Throwable $e ) {
+		if ( ! headers_sent() ) {
+			http_response_code( 500 );
+		}
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, $e->getMessage() );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
@@ -363,6 +367,7 @@ function rest_sync_db( WP_REST_Request $request ): void {
 	Sync_Stream\setup();
 
 	if ( ! class_exists( 'WordPress\\DataLiberation\\MySQLDumpProducer' ) ) {
+		http_response_code( 503 );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'Reprint classes not available.' );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
@@ -391,6 +396,7 @@ function rest_sync_db( WP_REST_Request $request ): void {
 		);
 		// phpcs:enable WordPress.DB.RestrictedClasses.mysql__PDO
 	} catch ( \PDOException $e ) {
+		http_response_code( 500 );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'db_connect: ' . $e->getMessage() );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;
@@ -432,6 +438,9 @@ function rest_sync_db( WP_REST_Request $request ): void {
 			Sync_Stream\emit_marker( Sync_Stream\MARKER_END );
 		}
 	} catch ( \Throwable $e ) {
+		if ( ! headers_sent() ) {
+			http_response_code( 500 );
+		}
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, $e->getMessage() );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_DONE );
 		exit;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"dev": "vite",
 		"build": "vite build",
 		"watch": "vite build --watch",
-		"zip": "npm run build && zip -r live-sandbox-editor.zip live-sandbox-editor"
+		"zip": "npm run build && zip -r live-sandbox-editor.zip live-sandbox-editor",
+		"ci-check": "tsgo --noEmit && biome check . && npm run build && composer validate --strict && composer validate --strict --working-dir=live-sandbox-editor && find live-sandbox-editor src -path 'live-sandbox-editor/vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l && composer lint:src"
 	},
 	"author": "sirreal",
 	"license": "GPL-2.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,14 @@
 	-->
 
 	<file>./live-sandbox-editor</file>
+	<!--
+	`./src` is intentionally NOT listed here. CI invokes phpcs with an
+	explicit `src/` path (see `composer lint:src` for the same command
+	locally) so the bundled-into-Playground PHP file gets linted in
+	isolation, without mixing in pre-existing plugin failures. Leaving
+	`./src` off this default file list keeps a bare `vendor/bin/phpcs`
+	scoped to plugin code; run `composer lint:src` for the sandbox lib.
+	-->
 	<exclude-pattern>./plugin-repo/*</exclude-pattern>
 	<exclude-pattern>./wordpress/*</exclude-pattern>
 	<exclude-pattern>\.m?js$</exclude-pattern>
@@ -121,6 +129,22 @@
 				<element value="live_sandbox_editor"/>
 			</property>
 		</properties>
+		<!--
+		`src/post-import-fixups.php` is a self-contained library bundled
+		into the JS entry as a `?raw` string and written to /tmp inside
+		Playground at runtime. It never executes in a host WordPress
+		alongside arbitrary plugins, so the prefix-collision rationale
+		doesn't apply; the file uses a short `lse_` prefix for readability.
+		Scoped to the one file deliberately — any future src/*.php must
+		opt in here explicitly so prefix enforcement isn't lost silently.
+		-->
+		<exclude-pattern>./src/post-import-fixups\.php$</exclude-pattern>
+		<!--
+		`src/uploads-passthrough.mu.php` is the same shape: a Playground
+		mu-plugin written into the sandbox at install time, never loaded
+		by host WordPress. Same `lse_` prefix convention.
+		-->
+		<exclude-pattern>./src/uploads-passthrough\.mu\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.Files.FileName">

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -270,11 +270,16 @@ async function runSqlFromDisk(
 			$wpdb->suppress_errors();
 			$wpdb->hide_errors();
 
-			$sql = file_get_contents('${sqlPath}');
-			$len = strlen($sql);
-			$i = 0;
-			$start = 0;
-			$in_str = false;
+			$fp = fopen('${sqlPath}', 'rb');
+			if (!$fp) {
+				echo json_encode(array(
+					'ok' => 0,
+					'fail' => 1,
+					'sampleErrors' => array(array('error' => 'fopen failed', 'sql' => '${sqlPath}')),
+				));
+				exit;
+			}
+
 			$ok = 0;
 			$fail = 0;
 			$errors = array();
@@ -298,39 +303,64 @@ async function runSqlFromDisk(
 				}
 			};
 
-			while ($i < $len) {
-				$c = $sql[$i];
-				if (!$in_str) {
-					if ($c === '-' && $i + 1 < $len && $sql[$i + 1] === '-') {
-						$nl = strpos($sql, "\\n", $i);
-						$i = ($nl === false) ? $len : $nl + 1;
-						continue;
-					}
-					if ($c === '/' && $i + 1 < $len && $sql[$i + 1] === '*') {
-						$end = strpos($sql, '*/', $i + 2);
-						$i = ($end === false) ? $len : $end + 2;
-						continue;
-					}
-					if ($c === "'") {
-						$in_str = true;
-					} elseif ($c === ';') {
-						$run_stmt(substr($sql, $start, $i - $start + 1));
-						$start = $i + 1;
-					}
-				} else {
-					if ($c === "'") {
-						if ($i + 1 < $len && $sql[$i + 1] === "'") {
-							$i++;
-						} else {
-							$in_str = false;
-						}
+			// Streaming statement splitter. Memory: chunk_size + one statement.
+			// State persists across reads so strings/comments/statements straddling
+			// a chunk boundary are handled identically to the in-memory version.
+			$stmt  = '';
+			$state = 'normal'; // normal | string | line_comment | block_comment
+			$tail  = '';       // 1-byte carry so $next is always defined inside the loop
+
+			$read_failed = false;
+			while (!feof($fp)) {
+				$chunk = fread($fp, 262144);
+				if ($chunk === false) { $read_failed = true; break; }
+				if ($chunk === '') continue;
+
+				$buf  = $tail . $chunk;
+				$blen = strlen($buf);
+				$eof  = feof($fp);
+				$end  = $eof ? $blen : $blen - 1;
+				$tail = $eof ? ''    : $buf[$blen - 1];
+
+				for ($i = 0; $i < $end; $i++) {
+					$c    = $buf[$i];
+					$next = ($i + 1 < $blen) ? $buf[$i + 1] : '';
+
+					if ($state === 'normal') {
+						if ($c === '-' && $next === '-') { $state = 'line_comment';  $i++; continue; }
+						if ($c === '/' && $next === '*') { $state = 'block_comment'; $i++; continue; }
+						if ($c === "'")                  { $state = 'string'; $stmt .= $c; continue; }
+						if ($c === ';')                  { $stmt .= $c; $run_stmt($stmt); $stmt = ''; continue; }
+						$stmt .= $c;
+					} elseif ($state === 'string') {
+						if ($c === "'" && $next === "'") { $stmt .= "''"; $i++; continue; }
+						if ($c === "'")                  { $state = 'normal'; $stmt .= $c; continue; }
+						$stmt .= $c;
+					} elseif ($state === 'line_comment') {
+						if ($c === "\\n") $state = 'normal';
+					} else { // block_comment
+						if ($c === '*' && $next === '/') { $state = 'normal'; $i++; }
 					}
 				}
-				$i++;
+
+				// 2-char-token cases above peek into $buf[$blen-1] (the deferred
+				// byte) and advance $i past it. When that happens the loop exits
+				// with $i > $end; clear $tail so the deferred byte isn't replayed.
+				if ($i > $end) $tail = '';
 			}
-			if ($start < $len) {
-				$run_stmt(substr($sql, $start));
+
+			if ($read_failed) {
+				echo json_encode(array(
+					'ok' => $ok,
+					'fail' => $fail + 1,
+					'sampleErrors' => array_merge($errors, array(array('error' => 'fread failed', 'sql' => '${sqlPath}'))),
+				));
+				fclose($fp);
+				exit;
 			}
+
+			if (trim($stmt) !== '') $run_stmt($stmt);
+			fclose($fp);
 
 			echo json_encode(array(
 				'ok' => $ok,

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,10 +1,27 @@
 import type { PlaygroundClient } from '@wp-playground/client';
-import { BatchedDiskFlusher, readNdjson } from './streaming.js';
+import postImportFixupsPhp from './post-import-fixups.php?raw';
+import { BatchedDiskFlusher, readSyncStream } from './streaming.js';
 import { getAppData } from './types.js';
+import uploadsPassthroughMuPhp from './uploads-passthrough.mu.php?raw';
+
+const FIXUPS_PATH = '/tmp/lse-fixups.php';
 
 export interface DebugSettings {
 	scriptDebug: boolean;
 	wpDebug: boolean;
+}
+
+export interface SyncManifest {
+	plugins: string[];
+	themes: string[];
+	tables: string[];
+	uploads: boolean;
+}
+
+interface ManifestResponse {
+	manifest: SyncManifest;
+	siteUrl: string;
+	uploadsUrl: string;
 }
 
 async function getErrorResponseText(res: Response): Promise<string | null> {
@@ -38,19 +55,49 @@ export async function initPlayground(
 		await logSqliteIntegrationVersion(client);
 	}
 
-	onStatus('Importing site files…');
-	const filesOk = await importReprintFiles(client);
+	onStatus('Resolving sync manifest…');
+	const manifestResp = await fetchManifest();
+	// Future PR: surface a UI for the user to override `manifest` before
+	// kicking off the sync. For now, defaults: active plugins, active
+	// theme + parent, structural WP tables, no uploads.
+	const manifest = manifestResp.manifest;
 
-	if (filesOk) {
-		onStatus('Importing database…');
-		await importReprintDb(client, debugMode);
-
-		onStatus('Finalizing sandbox…');
-		await applyPostImportFixups(client);
+	if (debugMode) {
+		console.log('[live-sandbox-editor] manifest:', manifestResp);
 	}
+
+	const hasFiles =
+		manifest.plugins.length > 0 ||
+		manifest.themes.length > 0 ||
+		manifest.uploads;
+	const hasDb = manifest.tables.length > 0;
+
+	if (hasFiles) {
+		onStatus('Importing site files…');
+		await importFiles(client, manifest, debugMode);
+	}
+
+	if (hasDb) {
+		onStatus('Importing database…');
+		await importDb(client, manifest, debugMode);
+	}
+
+	onStatus('Finalizing sandbox…');
+	await applyPostImportFixups(client, hasDb ? manifestResp : null, onStatus);
 
 	await client.goTo('/');
 	return client;
+}
+
+async function fetchManifest(): Promise<ManifestResponse> {
+	const { restUrl, nonce } = getAppData();
+	const res = await fetch(`${restUrl}/sync-manifest`, {
+		headers: { 'X-WP-Nonce': nonce, Accept: 'application/json' },
+	});
+	if (!res.ok) {
+		throw new Error(`sync-manifest failed: ${res.status}`);
+	}
+	return (await res.json()) as ManifestResponse;
 }
 
 /**
@@ -85,9 +132,7 @@ async function logSqliteIntegrationVersion(
 			if ($found) {
 				$dir = dirname($found);
 				foreach (array(
-					// v3.0.0+ layout (monorepo restructure, PR #334).
 					$dir . '/wp-includes/database/sqlite/class-wp-sqlite-pdo-user-defined-functions.php',
-					// pre-v3 layout.
 					$dir . '/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php',
 					$dir . '/wp-includes/sqlite-ast/class-wp-sqlite-pdo-user-defined-functions.php',
 				) as $u) {
@@ -112,84 +157,82 @@ async function logSqliteIntegrationVersion(
 	);
 }
 
-/**
- * Stream wp-content files from the REST proxy directly into Playground
- * disk. Files are appended chunk-by-chunk via FILE_APPEND inside Playground;
- * the JS heap never holds a full file or a buffered response body.
- *
- * Returns true on success, false if the server reports an error.
- */
-async function importReprintFiles(client: PlaygroundClient): Promise<boolean> {
+async function postManifestStream(
+	endpoint: string,
+	manifest: SyncManifest,
+): Promise<Response> {
 	const { restUrl, nonce } = getAppData();
-	const docroot = await client.documentRoot;
-
-	const res = await fetch(`${restUrl}/reprint-files`, {
-		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
+	return fetch(`${restUrl}/${endpoint}`, {
+		method: 'POST',
+		headers: {
+			'X-WP-Nonce': nonce,
+			'Content-Type': 'application/json',
+			Accept: 'application/octet-stream',
+		},
+		body: JSON.stringify(manifest),
 	});
-
-	if (!res.ok) {
-		const errorText = await getErrorResponseText(res);
-		console.error(
-			'[live-sandbox-editor] Reprint file import failed:',
-			res.status,
-			errorText ?? '',
-		);
-		return false;
-	}
-
-	const flusher = new BatchedDiskFlusher(client);
-
-	try {
-		await readNdjson(res, async (rec) => {
-			if (rec.type !== 'file') return;
-			const fullPath = docroot + rec.path;
-			await flusher.addFileChunk(fullPath, rec.b64, rec.seq === 0);
-		});
-		await flusher.flush();
-	} catch (err) {
-		console.error('[live-sandbox-editor] File stream failed:', err);
-		return false;
-	}
-
-	return true;
 }
 
-/**
- * Stream the SQL dump from the REST proxy straight to a file inside
- * Playground, then execute it via an in-Playground splitter that reads
- * from disk. The full SQL never lives in JS or PHP memory — both sides
- * are bounded by the flusher's batch size.
- */
-async function importReprintDb(
+async function importFiles(
 	client: PlaygroundClient,
+	manifest: SyncManifest,
 	debugMode: boolean,
 ): Promise<void> {
-	const { restUrl, nonce } = getAppData();
-	const res = await fetch(`${restUrl}/reprint-db`, {
-		headers: { 'X-WP-Nonce': nonce, Accept: 'application/x-ndjson' },
-	});
-
+	const docroot = await client.documentRoot;
+	const res = await postManifestStream('sync-files', manifest);
 	if (!res.ok) {
 		const errorText = await getErrorResponseText(res);
 		console.error(
-			'[live-sandbox-editor] Reprint DB import failed:',
+			'[live-sandbox-editor] sync-files failed:',
 			res.status,
 			errorText ?? '',
 		);
 		return;
 	}
 
-	const flusher = new BatchedDiskFlusher(client);
+	const flusher = new BatchedDiskFlusher(client, {
+		// Logical paths begin with `/wp-content/...` — the Playground docroot
+		// lives at /wordpress (or similar), so prefix accordingly.
+		logicalToFullPath: (logical: string) => `${docroot}${logical}`,
+		debug: debugMode,
+	});
+
+	try {
+		await readSyncStream(res, flusher);
+		await flusher.finalize();
+	} catch (err) {
+		console.error('[live-sandbox-editor] file stream failed:', err);
+	}
+}
+
+async function importDb(
+	client: PlaygroundClient,
+	manifest: SyncManifest,
+	debugMode: boolean,
+): Promise<void> {
+	const res = await postManifestStream('sync-db', manifest);
+	if (!res.ok) {
+		const errorText = await getErrorResponseText(res);
+		console.error(
+			'[live-sandbox-editor] sync-db failed:',
+			res.status,
+			errorText ?? '',
+		);
+		return;
+	}
+
+	const flusher = new BatchedDiskFlusher(client, {
+		// SQL stream doesn't need a path mapper, but the constructor requires one.
+		logicalToFullPath: (p) => p,
+		debug: debugMode,
+	});
 	await flusher.resetSqlFile();
 
 	try {
-		await readNdjson(res, async (rec) => {
-			if (rec.type !== 'sql') return;
-			await flusher.addSqlChunk(rec.b64);
-		});
-		await flusher.flush();
+		await readSyncStream(res, flusher);
+		await flusher.finalize();
 	} catch (err) {
-		console.error('[live-sandbox-editor] DB stream failed:', err);
+		console.error('[live-sandbox-editor] db stream failed:', err);
 		return;
 	}
 
@@ -323,28 +366,110 @@ async function runSqlFromDisk(
 	}
 }
 
-async function applyPostImportFixups(client: PlaygroundClient): Promise<void> {
-	const docroot = await client.documentRoot;
-	const playgroundUrl = await client.absoluteUrl;
+function phpStringLiteral(s: string): string {
+	// PHP single-quoted: escape backslashes and single quotes only.
+	return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
 
+interface RewriteCtx {
+	hostUrl: string;
+	uploadsUrl: string;
+	playgroundUrl: string;
+}
+
+async function applyPostImportFixups(
+	client: PlaygroundClient,
+	dbContext: ManifestResponse | null,
+	onStatus: (status: string) => void,
+): Promise<void> {
+	const docroot = await client.documentRoot;
+	await client.writeFile(FIXUPS_PATH, postImportFixupsPhp);
+
+	// URL rewrite is conditional on a DB sync — without one, Playground's
+	// default options shouldn't be smashed with the host's URLs.
+	if (dbContext) {
+		const ctx: RewriteCtx = {
+			hostUrl: dbContext.siteUrl.replace(/\/$/, ''),
+			uploadsUrl: dbContext.uploadsUrl.replace(/\/$/, ''),
+			playgroundUrl: (await client.absoluteUrl).replace(/\/$/, ''),
+		};
+		await rewriteUrls(client, docroot, ctx, onStatus);
+		if (!dbContext.manifest.uploads) {
+			await installUploadsPassthrough(client, docroot, ctx.uploadsUrl);
+		}
+	}
+
+	// Self-deactivate runs unconditionally — file sync excludes the editor
+	// from copy, but `active_plugins` in the imported DB may still carry it.
 	await client.run({
 		code: `<?php
-			require('${docroot}/wp-load.php');
-			update_option('siteurl', '${playgroundUrl}');
-			update_option('home', '${playgroundUrl}');
+			require '${docroot}/wp-load.php';
+			require_once '${FIXUPS_PATH}';
+			lse_deactivate_self();
+		`,
+	});
+}
 
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+/**
+ * Install a mu-plugin that filters runtime upload-URL helpers
+ * (`wp_get_attachment_url`, `wp_calculate_image_srcset`) back at the
+ * host. Without this, every runtime-generated upload URL resolves to
+ * Playground's origin, where the file doesn't exist because uploads
+ * weren't synced.
+ *
+ * The mu-plugin maintains a skip list (`lse_uploads_passthrough_skip_urls`
+ * option, also exposed as a filter of the same name) so URLs we _don't_
+ * want redirected — chiefly media uploaded inside the sandbox post-sync —
+ * stay on playground origin. Newly added attachments append themselves
+ * to the skip list via the postmeta hooks in the mu-plugin.
+ */
+async function installUploadsPassthrough(
+	client: PlaygroundClient,
+	docroot: string,
+	hostUploadsUrl: string,
+): Promise<void> {
+	const muDir = `${docroot}/wp-content/mu-plugins`;
+	// Swap the whole PHP literal so `phpStringLiteral` handles escaping;
+	// the mu-plugin guards against missed substitutions by sniffing for
+	// the `__LSE_` prefix on its constant value before registering hooks.
+	const muPlugin = uploadsPassthroughMuPhp.replace(
+		"'__LSE_HOST_UPLOADS_URL__'",
+		phpStringLiteral(hostUploadsUrl),
+	);
+	// One round-trip: mkdir + write together. Embedding the whole
+	// mu-plugin via `phpStringLiteral` means PHP un-escapes the literal
+	// back to the original source byte-for-byte before `file_put_contents`
+	// writes it.
+	await client.run({
+		code: `<?php
+			$dir = ${phpStringLiteral(muDir)};
+			@mkdir( $dir, 0755, true );
+			file_put_contents(
+				$dir . '/lse-uploads-passthrough.php',
+				${phpStringLiteral(muPlugin)}
+			);
+		`,
+	});
+}
 
-			// Match by main-file postfix — the WP plugin dir name isn't stable.
-			$active   = (array) get_option('active_plugins', array());
-			$sitewide = is_multisite() ? array_keys((array) get_site_option('active_sitewide_plugins', array())) : array();
-			$entries  = array_filter(array_unique(array_merge($active, $sitewide)), static function ($entry) {
-				return str_ends_with($entry, '/live-sandbox-editor.php');
-			});
-
-			if ($entries) {
-				deactivate_plugins(array_values($entries), true);
-			}
+async function rewriteUrls(
+	client: PlaygroundClient,
+	docroot: string,
+	ctx: RewriteCtx,
+	onStatus: (status: string) => void,
+): Promise<void> {
+	onStatus('Rewriting site URLs…');
+	await client.run({
+		code: `<?php
+			require '${docroot}/wp-load.php';
+			require_once '${FIXUPS_PATH}';
+			update_option('siteurl', ${phpStringLiteral(ctx.playgroundUrl)});
+			update_option('home', ${phpStringLiteral(ctx.playgroundUrl)});
+			lse_rewrite_all_urls(
+				${phpStringLiteral(ctx.hostUrl)},
+				${phpStringLiteral(ctx.playgroundUrl)},
+				${phpStringLiteral(ctx.uploadsUrl)}
+			);
 		`,
 	});
 }

--- a/src/post-import-fixups.php
+++ b/src/post-import-fixups.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Post-import fixup library.
+ *
+ * Bundled into the JS entry as a raw string (`?raw` import), then
+ * `client.writeFile()`'d to `/tmp/lse-fixups.php` inside Playground at
+ * the start of `applyPostImportFixups`. Each subsequent `client.run()`
+ * `require_once`'s it. This file is **never** loaded by the host
+ * WordPress that ships this plugin — keep it self-contained.
+ *
+ * Each `lse_*` symbol is wrapped in `function_exists()` so the file is
+ * safe to `require_once` from any number of fresh PHP requests within
+ * one Playground session without `Cannot redeclare` fatals.
+ *
+ * @package Live_Sandbox_Editor
+ */
+
+if ( ! function_exists( 'lse_replace_string' ) ) {
+	/**
+	 * Replace $host with $playground in $s, leaving substrings of any URL
+	 * that begins with $uploads_url untouched (sentinel-protected swap).
+	 *
+	 * @param string $s           Source string.
+	 * @param string $host        Host site URL to replace.
+	 * @param string $playground  Playground URL to substitute in.
+	 * @param string $uploads_url Uploads base URL whose contents must not be rewritten.
+	 * @return string
+	 */
+	function lse_replace_string( $s, $host, $playground, $uploads_url ) {
+		if ( $host === $playground ) {
+			return $s;
+		}
+		$sentinel    = "\x00LSE_UPLOADS\x00";
+		$has_uploads = ( '' !== $uploads_url ) && ( false !== strpos( $s, $uploads_url ) );
+		if ( $has_uploads ) {
+			$s = str_replace( $uploads_url, $sentinel, $s );
+		}
+		if ( false !== strpos( $s, $host ) ) {
+			$s = str_replace( $host, $playground, $s );
+		}
+		if ( $has_uploads ) {
+			$s = str_replace( $sentinel, $uploads_url, $s );
+		}
+		return $s;
+	}
+}
+
+if ( ! function_exists( 'lse_replace_in_value' ) ) {
+	/**
+	 * Recursively replace $host with $playground in every string inside
+	 * $data, except where the string lies inside a URL that begins with
+	 * $uploads_url. Handles PHP-serialized values by inflating, recursing,
+	 * and reserializing.
+	 *
+	 * `unserialize` is called with `allowed_classes => ['stdClass']`.
+	 * Three reasons stacked together:
+	 *   1. POI defense — refuse to instantiate arbitrary classes from
+	 *      possibly-tampered DB content; gadget chains in `__wakeup` /
+	 *      `__destruct` cannot fire (stdClass has no magic methods).
+	 *   2. Sandbox correctness — the imported DB came from a host where
+	 *      arbitrary plugins may have stored their own classes in
+	 *      options/postmeta. Those classes don't exist in Playground's
+	 *      WP install; the allowlist turns them into
+	 *      `__PHP_Incomplete_Class` predictably instead of emitting
+	 *      warnings.
+	 *   3. stdClass is the common case in WP core and many plugins
+	 *      (widget options, theme_mods entries, etc.). Allowing it lets
+	 *      the rewrite recurse into the actual properties, rather than
+	 *      bailing on every serialized object.
+	 *
+	 * `__PHP_Incomplete_Class` instances are walked read-only and
+	 * returned untouched — PHP forbids property assignment on them and
+	 * a write would trigger a fatal. Strings inside such objects stay
+	 * as-is; in practice these come from custom plugin classes that
+	 * rarely store host URLs.
+	 *
+	 * The `$visited` `SplObjectStorage` threads through recursion to
+	 * break cycles in object graphs. Stock WP core data has none, but
+	 * custom plugin objects stored in options/postmeta have been
+	 * observed to hold back-references to themselves or to parent
+	 * objects, and PHP's call stack is the only thing stopping us
+	 * otherwise.
+	 *
+	 * @param mixed                 $data        Value to walk.
+	 * @param string                $host        Host site URL.
+	 * @param string                $playground  Playground URL.
+	 * @param string                $uploads_url Uploads base URL to preserve.
+	 * @param SplObjectStorage|null $visited     Object cycle tracker (internal).
+	 * @return mixed
+	 */
+	function lse_replace_in_value( $data, $host, $playground, $uploads_url, $visited = null ) {
+		if ( null === $visited ) {
+			$visited = new SplObjectStorage();
+		}
+		if ( is_string( $data ) ) {
+			if ( '' === $data ) {
+				return $data;
+			}
+			if ( is_serialized( $data ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- intentional: see allowed_classes rationale in docblock above.
+				$unser = @unserialize( $data, array( 'allowed_classes' => array( 'stdClass' ) ) );
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- mirrors the unserialize above; values are reserialized to preserve the on-disk shape.
+				if ( false !== $unser || serialize( false ) === $data ) {
+					$replaced = lse_replace_in_value( $unser, $host, $playground, $uploads_url, $visited );
+					// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- see comment above.
+					return serialize( $replaced );
+				}
+				// `is_serialized()` matched the shape but `unserialize()`
+				// rejected the payload — the value is structurally corrupt
+				// (truncated, hand-edited, encoding-mangled, etc.). A naive
+				// `str_replace` would desync the embedded `s:N:` byte
+				// counts and produce a value that no PHP code downstream
+				// can ever reload. Pass it through untouched so the
+				// corruption stays exactly as imported, and let whatever
+				// owns that row decide what to do with it.
+				return $data;
+			}
+			return lse_replace_string( $data, $host, $playground, $uploads_url );
+		}
+		if ( is_array( $data ) ) {
+			foreach ( $data as $k => $v ) {
+				$data[ $k ] = lse_replace_in_value( $v, $host, $playground, $uploads_url, $visited );
+			}
+			return $data;
+		}
+		if ( is_object( $data ) ) {
+			if ( $data instanceof \Closure ) {
+				return $data;
+			}
+			// Property assignment on `__PHP_Incomplete_Class` is a fatal
+			// — see the function's docblock for why instances reach us
+			// at all and why pass-through is the right behaviour.
+			if ( $data instanceof \__PHP_Incomplete_Class ) {
+				return $data;
+			}
+			if ( $visited->contains( $data ) ) {
+				return $data;
+			}
+			$visited->attach( $data );
+			foreach ( get_object_vars( $data ) as $k => $v ) {
+				$data->$k = lse_replace_in_value( $v, $host, $playground, $uploads_url, $visited );
+			}
+			return $data;
+		}
+		return $data;
+	}
+}
+
+if ( ! defined( 'LSE_REWRITE_BATCH_SIZE' ) ) {
+	define( 'LSE_REWRITE_BATCH_SIZE', 2000 );
+}
+
+if ( ! function_exists( 'lse_rewrite_all_urls' ) ) {
+	/**
+	 * Sweep every host-URL occurrence across the standard WP tables and
+	 * rewrite it to the Playground URL, preserving substrings of any URL
+	 * that begins with `$uploads_url`. Designed to run in a single
+	 * Playground PHP request: WordPress is bootstrapped once by the
+	 * caller, and this function loops every target table internally,
+	 * keyset-paginated in `$batch_size` chunks for memory hygiene (so
+	 * `$wpdb->get_results` never has to materialize an entire large
+	 * table at once).
+	 *
+	 * **Caller contract:** the target list is built here from
+	 * `$wpdb->prefix` plus a hardcoded set of core tables/columns. The
+	 * identifiers are interpolated into SQL (they cannot be passed
+	 * through `$wpdb->prepare()`, which only parameterizes values). The
+	 * allowlist is intentionally local to this function — do not extend
+	 * it with caller-supplied table or column names without re-auditing
+	 * the suppression below.
+	 *
+	 * @param string $host        Host site URL.
+	 * @param string $playground  Playground URL.
+	 * @param string $uploads_url Uploads base URL to preserve.
+	 * @param int    $batch_size  Rows per SELECT (memory bound, not a request bound).
+	 * @return array{scanned:int,updated:int}
+	 */
+	function lse_rewrite_all_urls( $host, $playground, $uploads_url, $batch_size = LSE_REWRITE_BATCH_SIZE ) {
+		global $wpdb;
+		if ( $host === $playground ) {
+			return array(
+				'scanned' => 0,
+				'updated' => 0,
+			);
+		}
+
+		$prefix  = $wpdb->prefix;
+		$targets = array(
+			array(
+				'table' => $prefix . 'options',
+				'pk'    => 'option_id',
+				'cols'  => array( 'option_value' ),
+			),
+			array(
+				'table' => $prefix . 'postmeta',
+				'pk'    => 'meta_id',
+				'cols'  => array( 'meta_value' ),
+			),
+			array(
+				'table' => $prefix . 'usermeta',
+				'pk'    => 'umeta_id',
+				'cols'  => array( 'meta_value' ),
+			),
+			array(
+				'table' => $prefix . 'termmeta',
+				'pk'    => 'meta_id',
+				'cols'  => array( 'meta_value' ),
+			),
+			array(
+				'table' => $prefix . 'commentmeta',
+				'pk'    => 'meta_id',
+				'cols'  => array( 'meta_value' ),
+			),
+			array(
+				'table' => $prefix . 'posts',
+				'pk'    => 'ID',
+				'cols'  => array( 'post_content', 'post_excerpt', 'post_title', 'guid' ),
+			),
+			array(
+				'table' => $prefix . 'comments',
+				'pk'    => 'comment_ID',
+				'cols'  => array( 'comment_content' ),
+			),
+			array(
+				'table' => $prefix . 'links',
+				'pk'    => 'link_id',
+				'cols'  => array( 'link_url', 'link_image' ),
+			),
+		);
+
+		$existing      = lse_existing_tables();
+		$total_scanned = 0;
+		$total_updated = 0;
+
+		foreach ( $targets as $t ) {
+			$table = $t['table'];
+			if ( empty( $existing[ $table ] ) ) {
+				continue;
+			}
+			$pk       = $t['pk'];
+			$cols     = $t['cols'];
+			$cols_sql = '`' . implode( '`, `', $cols ) . '`';
+			$last_pk  = 0;
+			while ( true ) {
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table/$pk/$cols are SQL identifiers; $wpdb->prepare() can only parameterize values, not identifiers. Per the caller contract documented above, every entry comes from the local hardcoded allowlist built above from $wpdb->prefix plus literal core column names. If a future change accepts caller-supplied identifiers here, this suppression hides a real injection — re-audit before relaxing the allowlist.
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT `{$pk}`, {$cols_sql} FROM `{$table}` WHERE `{$pk}` > %d ORDER BY `{$pk}` ASC LIMIT %d",
+						$last_pk,
+						$batch_size
+					),
+					ARRAY_A
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				if ( ! $rows ) {
+					break;
+				}
+				foreach ( $rows as $row ) {
+					$last_pk = (int) $row[ $pk ];
+					$updates = array();
+					foreach ( $cols as $col ) {
+						$orig = $row[ $col ];
+						if ( ! is_string( $orig ) || '' === $orig ) {
+							continue;
+						}
+						$new = lse_replace_in_value( $orig, $host, $playground, $uploads_url );
+						if ( $new !== $orig ) {
+							$updates[ $col ] = $new;
+						}
+					}
+					if ( $updates ) {
+						$wpdb->update( $table, $updates, array( $pk => $last_pk ) );
+						++$total_updated;
+					}
+				}
+				$total_scanned += count( $rows );
+				if ( count( $rows ) < $batch_size ) {
+					break;
+				}
+			}
+		}
+
+		return array(
+			'scanned' => $total_scanned,
+			'updated' => $total_updated,
+		);
+	}
+}
+
+if ( ! function_exists( 'lse_existing_tables' ) ) {
+	/**
+	 * Return a `[table_name => true]` map for every table in the current
+	 * MySQL/SQLite database. Caller intersects with its target list —
+	 * one round-trip beats `SHOW TABLES LIKE %s` per target.
+	 */
+	function lse_existing_tables() {
+		global $wpdb;
+		$rows = $wpdb->get_col( 'SHOW TABLES' );
+		return array_fill_keys( (array) $rows, true );
+	}
+}
+
+if ( ! function_exists( 'lse_deactivate_self' ) ) {
+	/**
+	 * Match by main-file postfix — the WP plugin dir name isn't stable
+	 * (users may rename or symlink the plugin directory).
+	 */
+	function lse_deactivate_self() {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$active   = (array) get_option( 'active_plugins', array() );
+		$sitewide = is_multisite()
+			? array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) )
+			: array();
+		$entries  = array_filter(
+			array_unique( array_merge( $active, $sitewide ) ),
+			static function ( $entry ) {
+				return str_ends_with( $entry, '/live-sandbox-editor.php' );
+			}
+		);
+		if ( $entries ) {
+			deactivate_plugins( array_values( $entries ), true );
+		}
+	}
+}

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,138 +1,391 @@
 import type { PlaygroundClient } from '@wp-playground/client';
 
-export type NdjsonRecord =
-	| { type: 'file'; path: string; b64: string; seq: number; final: boolean }
-	| { type: 'sql'; b64: string }
-	| { type: 'end' }
-	| { type: 'err'; message: string };
+/**
+ * Wire format consumed here — matches `inc/sync-stream.php` on the server:
+ *
+ *   \n#LSE:FILE:<urlencoded path>\n   start a file record
+ *   \n#LSE:SQL\n                       start a SQL record
+ *   \n#LSE:END\n                       end of current record's payload
+ *   \n#LSE:DONE\n                      end of stream
+ *   \n#LSE:ERR:<urlencoded message>\n  fatal error (terminal)
+ *
+ * Between START and END the body is base64 — the producer aligns its
+ * encoding to 3-byte input boundaries so the concatenated stream is valid
+ * base64 and can be decoded incrementally in 4-char chunks.
+ */
+
+const MARKER_PREFIX = '\n#LSE:';
+
+type ParserState =
+	| { kind: 'pre' }
+	| { kind: 'idle' }
+	| { kind: 'file'; path: string }
+	| { kind: 'sql' }
+	| { kind: 'done' };
+
+export interface PayloadHandler {
+	onFileStart(path: string): Promise<void>;
+	onFileBytes(path: string, bytes: Uint8Array): Promise<void>;
+	onFileEnd(path: string): Promise<void>;
+	onSqlBytes(bytes: Uint8Array): Promise<void>;
+}
 
 /**
- * Read an NDJSON response body line by line, invoking `onRecord` for each
- * parsed JSON object. Resolves cleanly only when the server emits a final
- * `{t:"end"}` record; throws on `{t:"err"}` or premature EOF.
- *
- * Uses the streaming `TextDecoder` flag so multi-byte UTF-8 sequences split
- * across chunk boundaries are joined correctly.
+ * Read a chunked-terminator response, dispatching decoded payload bytes to
+ * the supplied handler. Resolves when a `DONE` marker is seen; throws on
+ * `ERR`, an unterminated stream, or invalid framing.
  */
-export async function readNdjson(
+export async function readSyncStream(
 	res: Response,
-	onRecord: (rec: NdjsonRecord) => Promise<void>,
+	handler: PayloadHandler,
 ): Promise<void> {
 	if (!res.body) {
 		throw new Error('Response has no body');
 	}
 	const reader = res.body.getReader();
 	const decoder = new TextDecoder('utf-8');
-	let buf = '';
-	let sawEnd = false;
 
-	while (!sawEnd) {
+	let state: ParserState = { kind: 'pre' };
+	let buf = '';
+	let pendingB64 = '';
+
+	const emitDecoded = async (decodable: string): Promise<void> => {
+		if (decodable.length === 0) return;
+		const bytes = base64ToBytes(decodable);
+		if (state.kind === 'file') {
+			await handler.onFileBytes(state.path, bytes);
+		} else if (state.kind === 'sql') {
+			await handler.onSqlBytes(bytes);
+		}
+	};
+
+	const flushPending = async (): Promise<void> => {
+		if (pendingB64.length === 0) return;
+		// Producer pads with `=` on finalize, so when END is reached the
+		// total payload length is a multiple of 4 and pendingB64 is either
+		// empty or a complete final quartet.
+		if (pendingB64.length % 4 !== 0) {
+			throw new Error(
+				`Stream framing: ${pendingB64.length} unaligned base64 chars at record end`,
+			);
+		}
+		const tail = pendingB64;
+		pendingB64 = '';
+		await emitDecoded(tail);
+	};
+
+	const handleMarker = async (line: string): Promise<void> => {
+		// `line` is the marker without leading \n or trailing \n.
+		if (!line.startsWith('#LSE:')) {
+			throw new Error(`Stream framing: bad marker ${line}`);
+		}
+		const body = line.slice('#LSE:'.length);
+		const colon = body.indexOf(':');
+		const name = colon < 0 ? body : body.slice(0, colon);
+		const arg = colon < 0 ? null : decodeURIComponent(body.slice(colon + 1));
+
+		switch (name) {
+			case 'FILE': {
+				if (state.kind === 'file' || state.kind === 'sql') {
+					throw new Error('Unexpected FILE marker mid-record');
+				}
+				if (!arg) {
+					throw new Error('FILE marker missing path');
+				}
+				state = { kind: 'file', path: arg };
+				pendingB64 = '';
+				await handler.onFileStart(arg);
+				return;
+			}
+			case 'SQL': {
+				if (state.kind === 'file' || state.kind === 'sql') {
+					throw new Error('Unexpected SQL marker mid-record');
+				}
+				state = { kind: 'sql' };
+				pendingB64 = '';
+				return;
+			}
+			case 'END': {
+				await flushPending();
+				if (state.kind === 'file') {
+					await handler.onFileEnd(state.path);
+				} else if (state.kind !== 'sql') {
+					throw new Error('END marker outside a record');
+				}
+				state = { kind: 'idle' };
+				return;
+			}
+			case 'DONE': {
+				state = { kind: 'done' };
+				return;
+			}
+			case 'ERR': {
+				throw new Error(`Stream error: ${arg ?? '(no message)'}`);
+			}
+			default:
+				throw new Error(`Unknown stream marker: ${name}`);
+		}
+	};
+
+	const consumeMarker = async (atEof: boolean): Promise<boolean> => {
+		// Buf is expected to start with `\n#LSE:` (or possibly an incomplete prefix).
+		const eol = buf.indexOf('\n', 1);
+		if (eol < 0) {
+			if (atEof) {
+				throw new Error('Truncated marker at end of stream');
+			}
+			return false;
+		}
+		const line = buf.slice(1, eol);
+		buf = buf.slice(eol + 1);
+		await handleMarker(line);
+		return true;
+	};
+
+	const drain = async (atEof: boolean): Promise<void> => {
+		while (true) {
+			if (state.kind === 'done') return;
+
+			if (state.kind === 'pre' || state.kind === 'idle') {
+				const markerStart = buf.indexOf(MARKER_PREFIX);
+				if (markerStart < 0) {
+					const keep = Math.min(buf.length, MARKER_PREFIX.length - 1);
+					buf = buf.slice(buf.length - keep);
+					return;
+				}
+				if (markerStart > 0) {
+					buf = buf.slice(markerStart);
+				}
+				if (!(await consumeMarker(atEof))) return;
+				continue;
+			}
+
+			// Payload state — emit base64 up to the next marker.
+			const markerStart = buf.indexOf(MARKER_PREFIX);
+			let payloadEnd: number;
+			if (markerStart < 0) {
+				const safeEnd = Math.max(0, buf.length - (MARKER_PREFIX.length - 1));
+				if (safeEnd === 0) return;
+				payloadEnd = safeEnd;
+			} else {
+				payloadEnd = markerStart;
+			}
+
+			const slice = buf.slice(0, payloadEnd);
+			buf = buf.slice(payloadEnd);
+
+			// Producer never emits whitespace inside payload; strip
+			// defensively to tolerate any proxy that line-wraps.
+			const compact = slice.replace(/\s+/g, '');
+			if (compact.length > 0) {
+				const combined = pendingB64 + compact;
+				const aligned = combined.length - (combined.length % 4);
+				const decodable = combined.slice(0, aligned);
+				pendingB64 = combined.slice(aligned);
+				await emitDecoded(decodable);
+			}
+
+			if (markerStart < 0) return;
+			if (!(await consumeMarker(atEof))) return;
+		}
+	};
+
+	while (true) {
 		const { value, done } = await reader.read();
 		if (done) {
 			buf += decoder.decode();
+			await drain(true);
 			break;
 		}
 		buf += decoder.decode(value, { stream: true });
-
-		let nl = buf.indexOf('\n');
-		while (nl >= 0) {
-			const line = buf.slice(0, nl);
-			buf = buf.slice(nl + 1);
-			if (!line) continue;
-			const rec = JSON.parse(line) as NdjsonRecord;
-			if (rec.type === 'err') {
-				throw new Error(`Stream error: ${rec.message}`);
-			}
-			if (rec.type === 'end') {
-				sawEnd = true;
-				break;
-			}
-			await onRecord(rec);
-			nl = buf.indexOf('\n');
-		}
+		await drain(false);
+		// TS narrows `state` based on direct assignments here; mutations
+		// happen inside closures it can't see, so cast to read fresh.
+		if ((state as ParserState).kind === 'done') break;
 	}
 
-	if (buf.trim().length > 0) {
-		throw new Error(
-			`Stream ended with unterminated record: ${buf.slice(0, 120)}`,
+	if ((state as ParserState).kind !== 'done') {
+		throw new Error('Stream ended without DONE marker');
+	}
+	if (pendingB64.length > 0) {
+		throw new Error('Stream ended with unflushed base64 tail');
+	}
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+	const bin = atob(b64);
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let bin = '';
+	const chunk = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunk) {
+		bin += String.fromCharCode(
+			...bytes.subarray(i, Math.min(i + chunk, bytes.length)),
 		);
 	}
-	if (!sawEnd) {
-		throw new Error('Stream ended without {"t":"end"} marker (truncated)');
-	}
+	return btoa(bin);
 }
 
-interface PendingFileChunk {
+interface PendingFile {
 	kind: 'file';
 	path: string;
-	b64: string;
 	first: boolean;
+	b64: string;
 }
-
-interface PendingSqlChunk {
+interface PendingSql {
 	kind: 'sql';
 	b64: string;
 }
-
-type PendingChunk = PendingFileChunk | PendingSqlChunk;
+type Pending = PendingFile | PendingSql;
 
 /**
- * Buffers incoming chunks and flushes them inside Playground via a single
- * PHP run that loops `file_put_contents(..., FILE_APPEND)` per chunk.
- *
- * Trades a small bounded JS-side buffer (default 4 MB) for far fewer PHP
+ * Buffers decoded byte chunks and flushes them inside Playground via a
+ * single PHP run that loops `file_put_contents(..., FILE_APPEND)` per
+ * chunk. Trades a small bounded JS-side buffer for far fewer PHP
  * round-trips than per-chunk flushing. Total memory is bounded by
  * `flushBytes`, regardless of export size.
  */
-export class BatchedDiskFlusher {
-	private queue: PendingChunk[] = [];
+export class BatchedDiskFlusher implements PayloadHandler {
+	private queue: Pending[] = [];
 	private queuedBytes = 0;
 	private readonly flushBytes: number;
 	private readonly client: PlaygroundClient;
 	private readonly sqlPath: string;
+	private readonly logicalToFullPath: (logical: string) => string;
+	private firstByPath: Map<string, boolean> = new Map();
+	private readonly debug: boolean;
+	private currentAssetKey: string | null = null;
+	private assetBytes = 0;
+	private assetFiles = 0;
 
 	constructor(
 		client: PlaygroundClient,
-		options: { flushBytes?: number; sqlPath?: string } = {},
+		options: {
+			flushBytes?: number;
+			sqlPath?: string;
+			logicalToFullPath: (logical: string) => string;
+			debug?: boolean;
+		},
 	) {
 		this.client = client;
 		this.flushBytes = options.flushBytes ?? 4 * 1024 * 1024;
 		this.sqlPath = options.sqlPath ?? '/tmp/lse-import.sql';
+		this.logicalToFullPath = options.logicalToFullPath;
+		this.debug = options.debug ?? false;
+	}
+
+	private assetKeyFor(path: string): string {
+		// Wire-format invariant: paths emitted by the producer
+		// (`inc/manifest.php` `collect_files()` with `$logical_base`) are
+		// always normalized under `/wp-content/{plugins,themes,uploads}/…`,
+		// regardless of the host's actual `WP_PLUGIN_DIR` / theme-root /
+		// uploads basedir. If you change that convention on the producer,
+		// update the pattern here so the debug log keeps grouping correctly.
+		const m = path.match(
+			/^\/wp-content\/(plugins|themes|uploads)(?:\/([^/]+))?/,
+		);
+		if (!m) return `other (${path})`;
+		if (m[1] === 'uploads') return 'uploads';
+		const slug = m[2] ?? '(unknown)';
+		return `${m[1] === 'plugins' ? 'plugin' : 'theme'}: ${slug}`;
+	}
+
+	private closeAsset(): void {
+		if (this.currentAssetKey === null) return;
+		if (this.debug) {
+			console.log(
+				`[live-sandbox-editor] Completed transfer of ${this.currentAssetKey} (${this.assetFiles} files, ${this.assetBytes} bytes)`,
+			);
+		}
+		this.currentAssetKey = null;
+		this.assetBytes = 0;
+		this.assetFiles = 0;
 	}
 
 	getSqlPath(): string {
 		return this.sqlPath;
 	}
 
-	async addFileChunk(path: string, b64: string, first: boolean): Promise<void> {
-		this.queue.push({ kind: 'file', path, b64, first });
-		this.queuedBytes += b64.length;
-		if (this.queuedBytes >= this.flushBytes) {
-			await this.flush();
-		}
-	}
-
-	async addSqlChunk(b64: string): Promise<void> {
-		this.queue.push({ kind: 'sql', b64 });
-		this.queuedBytes += b64.length;
-		if (this.queuedBytes >= this.flushBytes) {
-			await this.flush();
-		}
-	}
-
-	/**
-	 * Truncate the on-disk SQL file before streaming begins. Required because
-	 * `addSqlChunk` always appends.
-	 */
 	async resetSqlFile(): Promise<void> {
 		await this.client.writeFile(this.sqlPath, new Uint8Array(0));
 	}
 
+	async onFileStart(path: string): Promise<void> {
+		this.firstByPath.set(path, true);
+		if (this.debug) {
+			const key = this.assetKeyFor(path);
+			if (key !== this.currentAssetKey) {
+				this.closeAsset();
+				this.currentAssetKey = key;
+				console.log(`[live-sandbox-editor] Starting transfer of ${key}`);
+			}
+			this.assetFiles++;
+		}
+	}
+
+	async onFileBytes(path: string, bytes: Uint8Array): Promise<void> {
+		const first = this.firstByPath.get(path) === true;
+		if (first) this.firstByPath.set(path, false);
+		this.queue.push({
+			kind: 'file',
+			path,
+			first,
+			b64: bytesToBase64(bytes),
+		});
+		this.queuedBytes += bytes.length;
+		if (this.debug) this.assetBytes += bytes.length;
+		if (this.queuedBytes >= this.flushBytes) {
+			await this.flush();
+		}
+	}
+
+	async onFileEnd(path: string): Promise<void> {
+		// Zero-byte file: no onFileBytes was ever called, so nothing was
+		// queued. Emit a marker chunk so the receiver creates the file.
+		if (this.firstByPath.get(path) === true) {
+			this.queue.push({ kind: 'file', path, first: true, b64: '' });
+		}
+		this.firstByPath.delete(path);
+	}
+
+	async onSqlBytes(bytes: Uint8Array): Promise<void> {
+		this.queue.push({ kind: 'sql', b64: bytesToBase64(bytes) });
+		this.queuedBytes += bytes.length;
+		if (this.queuedBytes >= this.flushBytes) {
+			await this.flush();
+		}
+	}
+
+	async finalize(): Promise<void> {
+		this.closeAsset();
+		await this.flush();
+	}
+
 	async flush(): Promise<void> {
 		if (this.queue.length === 0) return;
-		const items = this.queue;
+		const itemCount = this.queue.length;
+		const flushedBytes = this.queuedBytes;
+		const items = this.queue.map((p) =>
+			p.kind === 'file'
+				? {
+						kind: 'file' as const,
+						path: this.logicalToFullPath(p.path),
+						first: p.first,
+						b64: p.b64,
+					}
+				: { kind: 'sql' as const, b64: p.b64 },
+		);
 		this.queue = [];
 		this.queuedBytes = 0;
+		if (this.debug) {
+			console.log(
+				`[live-sandbox-editor] Flushing ${itemCount} chunks (${flushedBytes} bytes) to Playground`,
+			);
+		}
 
 		const payload = JSON.stringify({ items, sqlPath: this.sqlPath });
 

--- a/src/uploads-passthrough.mu.php
+++ b/src/uploads-passthrough.mu.php
@@ -10,9 +10,12 @@
  * URL is appended to a skip list at attachment-meta time.
  *
  * Skip list lives in the `lse_uploads_passthrough_skip_urls` option
- * (array of URL prefixes). Hook the `lse_uploads_passthrough_skip_urls`
- * filter to extend it at runtime — e.g. once partial media sync lands,
- * the host plugin can append the synced subset.
+ * as full upload URLs; the matcher accepts an exact match or a
+ * WP-generated sized variant (`-WxH` injected before the extension)
+ * so all variants share one entry. Hook the
+ * `lse_uploads_passthrough_skip_urls` filter to extend it at runtime —
+ * e.g. once partial media sync lands, the host plugin can append the
+ * synced subset.
  *
  * `LSE_PASSTHROUGH_HOST_UPLOADS_URL` is templated in by the editor at
  * install time (placeholder is rejected by the guard below if the
@@ -75,8 +78,17 @@ function lse_passthrough_skip_list( bool $reset = false ): array {
  * @return bool
  */
 function lse_passthrough_is_skipped( string $url ): bool {
-	foreach ( lse_passthrough_skip_list() as $prefix ) {
-		if ( str_starts_with( $url, $prefix ) ) {
+	foreach ( lse_passthrough_skip_list() as $entry ) {
+		if ( $url === $entry ) {
+			return true;
+		}
+		$dot = strrpos( $entry, '.' );
+		if ( false === $dot ) {
+			continue;
+		}
+		$base = substr( $entry, 0, $dot );
+		$ext  = substr( $entry, $dot );
+		if ( str_starts_with( $url, $base . '-' ) && str_ends_with( $url, $ext ) ) {
 			return true;
 		}
 	}

--- a/src/uploads-passthrough.mu.php
+++ b/src/uploads-passthrough.mu.php
@@ -86,9 +86,14 @@ function lse_passthrough_is_skipped( string $url ): bool {
 		if ( false === $dot ) {
 			continue;
 		}
-		$base = substr( $entry, 0, $dot );
-		$ext  = substr( $entry, $dot );
-		if ( str_starts_with( $url, $base . '-' ) && str_ends_with( $url, $ext ) ) {
+		$base   = substr( $entry, 0, $dot );
+		$ext    = substr( $entry, $dot );
+		$prefix = $base . '-';
+		if ( ! str_starts_with( $url, $prefix ) || ! str_ends_with( $url, $ext ) ) {
+			continue;
+		}
+		$middle = substr( $url, strlen( $prefix ), -strlen( $ext ) );
+		if ( preg_match( '/^\d+x\d+$/', $middle ) ) {
 			return true;
 		}
 	}

--- a/src/uploads-passthrough.mu.php
+++ b/src/uploads-passthrough.mu.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Live Sandbox Editor — uploads URL passthrough.
+ *
+ * Auto-installed by the editor when a DB sync ran without an uploads
+ * sync. Imported attachments don't have their files in the local
+ * filesystem, so every runtime-generated upload URL is redirected back
+ * at the host where the file actually lives. Files uploaded inside the
+ * sandbox after the sync stay on playground URLs because the upload's
+ * URL is appended to a skip list at attachment-meta time.
+ *
+ * Skip list lives in the `lse_uploads_passthrough_skip_urls` option
+ * (array of URL prefixes). Hook the `lse_uploads_passthrough_skip_urls`
+ * filter to extend it at runtime — e.g. once partial media sync lands,
+ * the host plugin can append the synced subset.
+ *
+ * `LSE_PASSTHROUGH_HOST_UPLOADS_URL` is templated in by the editor at
+ * install time (placeholder is rejected by the guard below if the
+ * substitution somehow didn't happen).
+ *
+ * @package Live_Sandbox_Editor
+ */
+
+const LSE_PASSTHROUGH_HOST_UPLOADS_URL = '__LSE_HOST_UPLOADS_URL__';
+const LSE_PASSTHROUGH_OPTION           = 'lse_uploads_passthrough_skip_urls';
+
+if ( str_starts_with( LSE_PASSTHROUGH_HOST_UPLOADS_URL, '__LSE_' ) ) {
+	return;
+}
+
+/**
+ * Resolve the active skip list: option value extended by the
+ * `lse_uploads_passthrough_skip_urls` filter, then validated.
+ *
+ * Memoized within a request since image-heavy pages call this dozens
+ * of times via the srcset filter. `lse_passthrough_record_upload`
+ * resets the cache when it appends a new URL so within-request writes
+ * are visible to subsequent reads.
+ *
+ * @param bool $reset Internal — pass true from the recorder to invalidate.
+ * @return array<int,string>
+ */
+function lse_passthrough_skip_list( bool $reset = false ): array {
+	static $cache = null;
+	if ( $reset ) {
+		$cache = null;
+		return array();
+	}
+	if ( null !== $cache ) {
+		return $cache;
+	}
+	$stored = get_option( LSE_PASSTHROUGH_OPTION, array() );
+	if ( ! is_array( $stored ) ) {
+		$stored = array();
+	}
+	$list  = (array) apply_filters( LSE_PASSTHROUGH_OPTION, $stored );
+	$cache = array_values(
+		array_filter(
+			$list,
+			static fn( $v ) => is_string( $v ) && '' !== $v
+		)
+	);
+	return $cache;
+}
+
+/**
+ * Test whether $url should be left alone (kept on playground origin).
+ *
+ * Linear scan over the skip list. Acceptable for v1 — the list grows
+ * by one entry per in-sandbox upload and a typical session adds a
+ * handful at most. If real-world usage ever pushes the list past a few
+ * hundred entries, swap the array for a hash lookup keyed by URL prefix.
+ *
+ * @param string $url Candidate URL.
+ * @return bool
+ */
+function lse_passthrough_is_skipped( string $url ): bool {
+	foreach ( lse_passthrough_skip_list() as $prefix ) {
+		if ( str_starts_with( $url, $prefix ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Replace the playground uploads baseurl in $url with the host's.
+ *
+ * `wp_get_upload_dir()` re-applies the `upload_dir` filter chain on
+ * every call; the baseurl is cached per request so srcset rendering
+ * doesn't re-fire the chain once per source entry.
+ *
+ * @param string $url URL produced by WP using the playground baseurl.
+ * @return string $url unchanged if it's not under the playground baseurl,
+ *                otherwise the same path with the host baseurl swapped in.
+ */
+function lse_passthrough_swap_to_host( string $url ): string {
+	static $baseurl = null;
+	if ( null === $baseurl ) {
+		$upload_dir = wp_get_upload_dir();
+		$baseurl    = ( ! empty( $upload_dir['baseurl'] ) && is_string( $upload_dir['baseurl'] ) )
+			? $upload_dir['baseurl']
+			: '';
+	}
+	if ( '' === $baseurl ) {
+		return $url;
+	}
+	if ( ! str_starts_with( $url, $baseurl ) ) {
+		return $url;
+	}
+	return LSE_PASSTHROUGH_HOST_UPLOADS_URL . substr( $url, strlen( $baseurl ) );
+}
+
+add_filter(
+	'wp_get_attachment_url',
+	static function ( $url ) {
+		if ( ! is_string( $url ) || '' === $url ) {
+			return $url;
+		}
+		if ( lse_passthrough_is_skipped( $url ) ) {
+			return $url;
+		}
+		return lse_passthrough_swap_to_host( $url );
+	},
+	PHP_INT_MAX
+);
+
+add_filter(
+	'wp_calculate_image_srcset',
+	static function ( $sources ) {
+		if ( ! is_array( $sources ) ) {
+			return $sources;
+		}
+		foreach ( $sources as &$source ) {
+			if ( ! is_array( $source ) || ! isset( $source['url'] ) || ! is_string( $source['url'] ) ) {
+				continue;
+			}
+			if ( lse_passthrough_is_skipped( $source['url'] ) ) {
+				continue;
+			}
+			$source['url'] = lse_passthrough_swap_to_host( $source['url'] );
+		}
+		unset( $source );
+		return $sources;
+	},
+	PHP_INT_MAX
+);
+
+/**
+ * Persist newly uploaded media into the skip list. Hooks both
+ * `added_post_meta` and `updated_post_meta` because `update_attached_file()`
+ * routes through `update_post_meta()`, which fires one or the other
+ * depending on whether the meta row already existed.
+ *
+ * The DB import phase doesn't fire either hook — it writes rows via raw
+ * `$wpdb->update()`/`$wpdb->query()` and bypasses the metadata API
+ * entirely. The skip list therefore only accumulates entries for
+ * attachments created post-import.
+ *
+ * @param int    $meta_id    Unused — passed by the action signature.
+ * @param int    $post_id    Unused.
+ * @param string $meta_key   Postmeta key being written.
+ * @param mixed  $meta_value New value.
+ */
+function lse_passthrough_record_upload( $meta_id, $post_id, $meta_key, $meta_value ): void {
+	if ( '_wp_attached_file' !== $meta_key ) {
+		return;
+	}
+	if ( ! is_string( $meta_value ) || '' === $meta_value ) {
+		return;
+	}
+	$upload_dir = wp_get_upload_dir();
+	if ( empty( $upload_dir['baseurl'] ) || ! is_string( $upload_dir['baseurl'] ) ) {
+		return;
+	}
+	$url    = rtrim( $upload_dir['baseurl'], '/' ) . '/' . ltrim( $meta_value, '/' );
+	$stored = get_option( LSE_PASSTHROUGH_OPTION, array() );
+	if ( ! is_array( $stored ) ) {
+		$stored = array();
+	}
+	if ( in_array( $url, $stored, true ) ) {
+		return;
+	}
+	$stored[] = $url;
+	update_option( LSE_PASSTHROUGH_OPTION, $stored, false );
+	lse_passthrough_skip_list( true );
+}
+add_action( 'added_post_meta', 'lse_passthrough_record_upload', 10, 4 );
+add_action( 'updated_post_meta', 'lse_passthrough_record_upload', 10, 4 );


### PR DESCRIPTION
## What

Replaces the NDJSON whole-site sync with a binary chunked stream framed by `\n#LSE:` sentinels, driven by a JSON manifest that scopes what gets synced. Goal: peak memory on **both** ends becomes a function of the wire chunk size, not of the site size.

## Defaults

The host site exposes a `/sync-manifest` REST endpoint that returns a default manifest plus the host site URL. Out of the box that is:

- **Plugins** — active plugins from `active_plugins` (and network-active on multisite), with the editor plugin itself excluded so it can't recursively load inside the sandbox.
- **Themes** — active stylesheet plus its template, so a child theme + parent are synced together.
- **Tables** — `$wpdb->tables('blog')` (+ `'global'` on multisite). Plugin/custom tables are skipped by default.
- **Uploads** — `false`. Attachment URLs are rewritten post-import to point back at the host site, so the sandbox renders media without copying it.

## How to customize

The Playground client posts the manifest back to `/sync-files` and `/sync-db`. The server normalizer (`Manifest\normalize`) validates and accepts:

- An arbitrary subset of `plugins[]` (entries in `folder/main.php` shape, or a single-file `slug.php`).
- An arbitrary subset of `themes[]` (stylesheet slugs).
- An arbitrary subset of `tables[]` — must match `^[A-Za-z0-9_]+$` and must start with `$wpdb->prefix` or `$wpdb->base_prefix`, so callers cannot dump arbitrary host tables.
- `uploads: true` to stream `wp-content/uploads` as well.

There is no UI yet — overriding the manifest is currently a JS-side concern (the client could swap the payload before posting). A UI is intentionally out of scope for this PR.

## Memory

Previously both ends had to materialize whole artifacts: the host built and held the SQL dump in memory, and Playground passed the dump through `file_get_contents()` before splitting. Peak memory on each side scaled with the site.

This PR streams everything:

- **Host side** — files go through `FileTreeProducer` in 256 KB chunks; the SQL dump is generated and emitted as it is produced. Files are base64-encoded incrementally with a 3-byte-aligned `B64_Streamer`, so producer output stays valid base64 across chunk boundaries.
- **Playground side** — the SQL import uses `fopen` + `fread(256 KB)` into a chunk-fed splitter that carries explicit state across reads (plus a 1-byte tail so 2-char tokens — quote-escape, `--`, `/*`, `*/` — that span a boundary still match).

Net effect: peak memory on each side drops from `O(site_size)` to roughly `O(chunk_size + max_statement_size)`.

## Extracted PHP

The post-import URL rewriter, the self-deactivation fixup, and the uploads-URL passthrough mu-plugin used to live as inline JS template strings inside `playground.ts`. They are now real `.php` files imported via Vite's `?raw`:

- `src/post-import-fixups.php` — URL rewrite + serialized-data walk + self-deactivation.
- `src/uploads-passthrough.mu.php` — host-resolving attachment URLs (incl. `srcset`) when uploads aren't synced.

Now they get IDE syntax highlighting, autocomplete, phpcs, and PHPStan-style analysis instead of sitting as opaque strings. A `phpcs.xml` and `composer.json` lint script land alongside, and the CI workflow runs `composer run lint` over the lot.

## Wire format

Documented at the top of `live-sandbox-editor/inc/sync-stream.php`:

```
\n#LSE:FILE:<urlencoded path>\n   start a file record
\n#LSE:SQL\n                       start a SQL record
\n#LSE:END\n                       end of current record
\n#LSE:DONE\n                      end of stream
\n#LSE:ERR:<urlencoded msg>\n      fatal error (terminal)
```

Markers begin with `\n#LSE:` — characters that cannot appear in base64 output, so the receiver scans unambiguously without escaping.