### PR TITLE
Add Setup view for scoping sandbox sync manifest

### DIFF
--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -140,24 +140,20 @@ function page_for_screen( string $hook_or_screen_id ): ?string {
 /**
  * Script-module data shared by both pages. Sync type with AppData TS interface.
  *
- * @phpstan-return array{
- *                   restUrl: string;
- *                   nonce: string;
- *                   siteUrl: string;
- *                   runUrl: string;
- *                   scriptDebug: bool;
- *                   wpDebug: bool;
- *                 }
+ * @param array<string,mixed> $data Existing filtered data.
  * @return array<string,mixed>
  */
-function app_data(): array {
-	return array(
-		'restUrl'     => rest_url( SLUG . '/v1' ),
-		'nonce'       => wp_create_nonce( 'wp_rest' ),
-		'siteUrl'     => get_site_url(),
-		'runUrl'      => menu_page_url( SLUG, false ),
-		'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-		'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
+function app_data( array $data ): array {
+	return array_merge(
+		$data,
+		array(
+			'restUrl'     => rest_url( SLUG . '/v1' ),
+			'nonce'       => wp_create_nonce( 'wp_rest' ),
+			'siteUrl'     => get_site_url(),
+			'runUrl'      => menu_page_url( SLUG, false ),
+			'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+			'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
+		)
 	);
 }
 

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -66,39 +66,13 @@ function init(): void {
  * @param string $hook_suffix Current hook suffix.
  */
 function enqueue_assets( string $hook_suffix ): void {
-	// Submenu hooks are prefixed with `sanitize_title( $parent_menu_title )`,
-	// not the parent slug. With menu title "Live Sandbox Editor" that
-	// resolves to SLUG, so the run page's hook is `SLUG . '_page_' . SLUG`.
-	$is_setup = $hook_suffix === 'toplevel_page_' . SETUP_SLUG;
-	$is_run   = $hook_suffix === SLUG . '_page_' . SLUG;
-	if ( ! $is_setup && ! $is_run ) {
+	$page = page_for_screen( $hook_suffix );
+	if ( null === $page ) {
 		return;
 	}
 
-	/**
-	 * Shared script-module data. Sync type with AppData TS interface.
-	 *
-	 * @phpstan-var array{
-	 *                   restUrl: string;
-	 *                   nonce: string;
-	 *                   siteUrl: string;
-	 *                   runUrl: string;
-	 *                   scriptDebug: bool;
-	 *                   wpDebug: bool;
-	 *                 }
-	 */
-	$app_data = static function (): array {
-		return array(
-			'restUrl'     => rest_url( SLUG . '/v1' ),
-			'nonce'       => wp_create_nonce( 'wp_rest' ),
-			'siteUrl'     => get_site_url(),
-			'runUrl'      => menu_page_url( SLUG, false ),
-			'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-			'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
-		);
-	};
-	add_filter( 'script_module_data_' . SLUG, $app_data );
-	add_filter( 'script_module_data_' . SETUP_SLUG, $app_data );
+	$module_id = 'setup' === $page ? SETUP_SLUG : SLUG;
+	add_filter( 'script_module_data_' . $module_id, __NAMESPACE__ . '\\app_data' );
 
 	wp_enqueue_style(
 		SLUG,
@@ -107,7 +81,7 @@ function enqueue_assets( string $hook_suffix ): void {
 		asset_version( 'style.css' )
 	);
 
-	if ( $is_setup ) {
+	if ( 'setup' === $page ) {
 		wp_enqueue_script_module(
 			SETUP_SLUG,
 			plugins_url( 'build/setup.js', __FILE__ ),
@@ -140,6 +114,50 @@ function enqueue_assets( string $hook_suffix ): void {
 		plugins_url( 'build/monaco.css', __FILE__ ),
 		array(),
 		asset_version( 'build/monaco.css' )
+	);
+}
+
+/**
+ * Classify a screen ID or admin-enqueue hook suffix into our two pages.
+ *
+ * Submenu hooks are prefixed with `sanitize_title( $parent_menu_title )`,
+ * not the parent slug. With menu title "Live Sandbox Editor" that resolves
+ * to SLUG, so the run page's hook is `SLUG . '_page_' . SLUG`.
+ *
+ * @param string $hook_or_screen_id Screen ID or admin_enqueue_scripts hook suffix.
+ * @return string|null 'setup', 'run', or null if not one of ours.
+ */
+function page_for_screen( string $hook_or_screen_id ): ?string {
+	if ( 'toplevel_page_' . SETUP_SLUG === $hook_or_screen_id ) {
+		return 'setup';
+	}
+	if ( SLUG . '_page_' . SLUG === $hook_or_screen_id ) {
+		return 'run';
+	}
+	return null;
+}
+
+/**
+ * Script-module data shared by both pages. Sync type with AppData TS interface.
+ *
+ * @phpstan-return array{
+ *                   restUrl: string;
+ *                   nonce: string;
+ *                   siteUrl: string;
+ *                   runUrl: string;
+ *                   scriptDebug: bool;
+ *                   wpDebug: bool;
+ *                 }
+ * @return array<string,mixed>
+ */
+function app_data(): array {
+	return array(
+		'restUrl'     => rest_url( SLUG . '/v1' ),
+		'nonce'       => wp_create_nonce( 'wp_rest' ),
+		'siteUrl'     => get_site_url(),
+		'runUrl'      => menu_page_url( SLUG, false ),
+		'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+		'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
 	);
 }
 
@@ -199,12 +217,7 @@ function render_run_page(): void {
 /** Show a notice when the vendored Reprint classes are unavailable. */
 function reprint_notice(): void {
 	$screen = get_current_screen();
-	if ( ! $screen ) {
-		return;
-	}
-	$is_setup = $screen->id === 'toplevel_page_' . SETUP_SLUG;
-	$is_run   = $screen->id === SLUG . '_page_' . SLUG;
-	if ( ! $is_setup && ! $is_run ) {
+	if ( ! $screen || null === page_for_screen( $screen->id ) ) {
 		return;
 	}
 	maybe_load_reprint();
@@ -261,10 +274,23 @@ function register_rest_routes(): void {
  * @param  WP_REST_Request $request Request.
  * @return array
  */
-function rest_sync_manifest( WP_REST_Request $request ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+function rest_sync_manifest( WP_REST_Request $request ): array {
 	$uploads     = wp_upload_dir( null, false );
 	$uploads_url = is_array( $uploads ) && ! empty( $uploads['baseurl'] ) ? (string) $uploads['baseurl'] : '';
 	$manifest    = Manifest\defaults();
+
+	$response = array(
+		'manifest'   => $manifest,
+		'siteUrl'    => (string) get_site_url(),
+		'uploadsUrl' => $uploads_url,
+	);
+
+	// Display labels are only used by the Setup view. Computing them
+	// requires walking every installed plugin via `get_plugins()`, so
+	// callers opt in with `?labels=1` to keep the run-page boot cheap.
+	if ( ! $request->get_param( 'labels' ) ) {
+		return $response;
+	}
 
 	// `get_plugins()` is admin-only and not autoloaded for REST callbacks.
 	require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -278,18 +304,14 @@ function rest_sync_manifest( WP_REST_Request $request ): array { // phpcs:ignore
 
 	$theme_labels = array();
 	foreach ( $manifest['themes'] as $slug ) {
-		$theme              = wp_get_theme( $slug );
-		$name               = $theme->exists() ? (string) $theme->get( 'Name' ) : $slug;
+		$theme                 = wp_get_theme( $slug );
+		$name                  = $theme->exists() ? (string) $theme->get( 'Name' ) : $slug;
 		$theme_labels[ $slug ] = '' !== $name ? $name : $slug;
 	}
 
-	return array(
-		'manifest'     => $manifest,
-		'siteUrl'      => (string) get_site_url(),
-		'uploadsUrl'   => $uploads_url,
-		'pluginLabels' => $plugin_labels,
-		'themeLabels'  => $theme_labels,
-	);
+	$response['pluginLabels'] = $plugin_labels;
+	$response['themeLabels']  = $theme_labels;
+	return $response;
 }
 
 /**

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -20,8 +20,9 @@ use FileTreeProducer;
 use WP_REST_Request;
 use WordPress\DataLiberation\MySQLDumpProducer;
 
-const SLUG    = 'live-sandbox-editor';
-const VERSION = '0.1';
+const SLUG       = 'live-sandbox-editor';
+const SETUP_SLUG = 'live-sandbox-editor-setup';
+const VERSION    = '0.1';
 
 require_once __DIR__ . '/inc/sync-stream.php';
 require_once __DIR__ . '/inc/manifest.php';
@@ -65,7 +66,54 @@ function init(): void {
  * @param string $hook_suffix Current hook suffix.
  */
 function enqueue_assets( string $hook_suffix ): void {
-	if ( $hook_suffix !== 'toplevel_page_' . SLUG ) {
+	// Submenu hooks are prefixed with `sanitize_title( $parent_menu_title )`,
+	// not the parent slug. With menu title "Live Sandbox Editor" that
+	// resolves to SLUG, so the run page's hook is `SLUG . '_page_' . SLUG`.
+	$is_setup = $hook_suffix === 'toplevel_page_' . SETUP_SLUG;
+	$is_run   = $hook_suffix === SLUG . '_page_' . SLUG;
+	if ( ! $is_setup && ! $is_run ) {
+		return;
+	}
+
+	/**
+	 * Shared script-module data. Sync type with AppData TS interface.
+	 *
+	 * @phpstan-var array{
+	 *                   restUrl: string;
+	 *                   nonce: string;
+	 *                   siteUrl: string;
+	 *                   runUrl: string;
+	 *                   scriptDebug: bool;
+	 *                   wpDebug: bool;
+	 *                 }
+	 */
+	$app_data = static function (): array {
+		return array(
+			'restUrl'     => rest_url( SLUG . '/v1' ),
+			'nonce'       => wp_create_nonce( 'wp_rest' ),
+			'siteUrl'     => get_site_url(),
+			'runUrl'      => menu_page_url( SLUG, false ),
+			'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+			'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
+		);
+	};
+	add_filter( 'script_module_data_' . SLUG, $app_data );
+	add_filter( 'script_module_data_' . SETUP_SLUG, $app_data );
+
+	wp_enqueue_style(
+		SLUG,
+		plugins_url( 'style.css', __FILE__ ),
+		array(),
+		asset_version( 'style.css' )
+	);
+
+	if ( $is_setup ) {
+		wp_enqueue_script_module(
+			SETUP_SLUG,
+			plugins_url( 'build/setup.js', __FILE__ ),
+			array( '@wordpress/interactivity' ),
+			asset_version( 'build/setup.js' )
+		);
 		return;
 	}
 
@@ -74,31 +122,6 @@ function enqueue_assets( string $hook_suffix ): void {
 		plugins_url( 'build/main.js', __FILE__ ),
 		array( '@wordpress/interactivity' ),
 		asset_version( 'build/main.js' )
-	);
-
-	add_filter(
-		'script_module_data_' . SLUG,
-		function (): array {
-			/**
-			 * Sync type with AppData TS interface.
-			 *
-			 * @phpstan-var array{
-			 *                   restUrl: string;
-			 *                   nonce: string;
-			 *                   siteUrl: string;
-			 *                   scriptDebug: bool;
-			 *                   wpDebug: bool;
-			 *                 }
-			 */
-			$app_data = array(
-				'restUrl'     => rest_url( SLUG . '/v1' ),
-				'nonce'       => wp_create_nonce( 'wp_rest' ),
-				'siteUrl'     => get_site_url(),
-				'scriptDebug' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-				'wpDebug'     => defined( 'WP_DEBUG' ) && WP_DEBUG,
-			);
-			return $app_data;
-		}
 	);
 
 	// Authoritative initial state. JS store ({@see src/store.ts}) only
@@ -112,12 +135,6 @@ function enqueue_assets( string $hook_suffix ): void {
 		)
 	);
 
-	wp_enqueue_style(
-		SLUG,
-		plugins_url( 'style.css', __FILE__ ),
-		array(),
-		asset_version( 'style.css' )
-	);
 	wp_enqueue_style(
 		SLUG . '-monaco',
 		plugins_url( 'build/monaco.css', __FILE__ ),
@@ -140,26 +157,54 @@ function asset_version( string $relative_path ): string {
 	return VERSION;
 }
 
-/** Register the admin menu page. */
+/** Register the admin menu pages. */
 function register_menu(): void {
 	add_menu_page(
 		'Live Sandbox Editor',
 		'Live Sandbox Editor',
 		'manage_options',
+		SETUP_SLUG,
+		__NAMESPACE__ . '\\render_setup_page'
+	);
+	// Override the auto-mirror submenu so the entry reads "Setup" instead of
+	// the parent menu's title.
+	add_submenu_page(
+		SETUP_SLUG,
+		'Setup',
+		'Setup',
+		'manage_options',
+		SETUP_SLUG,
+		__NAMESPACE__ . '\\render_setup_page'
+	);
+	add_submenu_page(
+		SETUP_SLUG,
+		'Live Sandbox Editor',
+		'Run',
+		'manage_options',
 		SLUG,
-		__NAMESPACE__ . '\\render_page'
+		__NAMESPACE__ . '\\render_run_page'
 	);
 }
 
-/** Render the admin page. */
-function render_page(): void {
+/** Render the setup admin page. */
+function render_setup_page(): void {
+	require __DIR__ . '/templates/setup-view.php';
+}
+
+/** Render the run admin page. */
+function render_run_page(): void {
 	require __DIR__ . '/templates/sandbox-view.php';
 }
 
 /** Show a notice when the vendored Reprint classes are unavailable. */
 function reprint_notice(): void {
 	$screen = get_current_screen();
-	if ( ! $screen || $screen->id !== 'toplevel_page_' . SLUG ) {
+	if ( ! $screen ) {
+		return;
+	}
+	$is_setup = $screen->id === 'toplevel_page_' . SETUP_SLUG;
+	$is_run   = $screen->id === SLUG . '_page_' . SLUG;
+	if ( ! $is_setup && ! $is_run ) {
 		return;
 	}
 	maybe_load_reprint();
@@ -219,10 +264,31 @@ function register_rest_routes(): void {
 function rest_sync_manifest( WP_REST_Request $request ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	$uploads     = wp_upload_dir( null, false );
 	$uploads_url = is_array( $uploads ) && ! empty( $uploads['baseurl'] ) ? (string) $uploads['baseurl'] : '';
+	$manifest    = Manifest\defaults();
+
+	// `get_plugins()` is admin-only and not autoloaded for REST callbacks.
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	$all_plugins   = get_plugins();
+	$plugin_labels = array();
+	foreach ( $manifest['plugins'] as $entry ) {
+		$plugin_labels[ $entry ] = isset( $all_plugins[ $entry ]['Name'] )
+			? (string) $all_plugins[ $entry ]['Name']
+			: $entry;
+	}
+
+	$theme_labels = array();
+	foreach ( $manifest['themes'] as $slug ) {
+		$theme              = wp_get_theme( $slug );
+		$name               = $theme->exists() ? (string) $theme->get( 'Name' ) : $slug;
+		$theme_labels[ $slug ] = '' !== $name ? $name : $slug;
+	}
+
 	return array(
-		'manifest'   => Manifest\defaults(),
-		'siteUrl'    => (string) get_site_url(),
-		'uploadsUrl' => $uploads_url,
+		'manifest'     => $manifest,
+		'siteUrl'      => (string) get_site_url(),
+		'uploadsUrl'   => $uploads_url,
+		'pluginLabels' => $plugin_labels,
+		'themeLabels'  => $theme_labels,
 	);
 }
 

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -4,28 +4,28 @@ html.wp-toolbar {
 	box-sizing: border-box;
 	height: 100%;
 }
-body.toplevel_page_live-sandbox-editor {
+body.live-sandbox-editor_page_live-sandbox-editor {
 	height: 100%;
 	margin: 0;
 	overflow: hidden;
 }
-body.toplevel_page_live-sandbox-editor #wpwrap {
+body.live-sandbox-editor_page_live-sandbox-editor #wpwrap {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 }
-body.toplevel_page_live-sandbox-editor #wpcontent {
+body.live-sandbox-editor_page_live-sandbox-editor #wpcontent {
 	flex: 1;
 	min-height: 0;
 	padding: 0;
 	display: flex;
 	flex-direction: column;
 }
-body.toplevel_page_live-sandbox-editor #wpbody {
+body.live-sandbox-editor_page_live-sandbox-editor #wpbody {
 	flex: 1;
 	min-height: 0;
 }
-body.toplevel_page_live-sandbox-editor #wpbody-content {
+body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	height: 100%;
 	box-sizing: border-box;
 	float: none;

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -293,3 +293,32 @@ body.toplevel_page_live-sandbox-editor #wpbody-content {
 		transform: rotate(360deg);
 	}
 }
+
+.lse-hidden {
+	display: none;
+}
+
+.lse-setup {
+	max-width: 720px;
+}
+
+.lse-setup .lse-setup-help {
+	color: #555;
+	margin-bottom: 16px;
+}
+
+.lse-setup .lse-setup-group {
+	border: 1px solid #ccd0d4;
+	padding: 12px 16px;
+	margin: 0 0 16px 0;
+}
+
+.lse-setup .lse-setup-group ul {
+	margin: 0;
+	max-height: 240px;
+	overflow-y: auto;
+}
+
+.lse-setup .lse-setup-group li {
+	margin: 0;
+}

--- a/live-sandbox-editor/templates/setup-view.php
+++ b/live-sandbox-editor/templates/setup-view.php
@@ -29,7 +29,7 @@ namespace Live_Sandbox_Editor;
 		</button>
 	</div>
 
-	<div data-wp-class--lse-hidden="state.loading">
+	<div data-wp-class--lse-hidden="state.loading || state.loadError">
 		<fieldset class="lse-setup-group">
 			<legend><?php esc_html_e( 'Plugins', 'live-sandbox-editor' ); ?></legend>
 			<ul>

--- a/live-sandbox-editor/templates/setup-view.php
+++ b/live-sandbox-editor/templates/setup-view.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Setup view template — checkbox UI to scope the sync manifest. Populates
+ * from the `/sync-manifest` REST endpoint via `live-sandbox-editor/setup`
+ * Interactivity store ({@see src/setup.ts}). The Run button navigates to
+ * the run admin page with the resolved manifest as a `?manifest=<json>`
+ * query parameter.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor;
+
+\defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="lse-setup-root" class="lse-setup" data-wp-interactive="live-sandbox-editor/setup">
+	<h1><?php esc_html_e( 'Configure sandbox sync', 'live-sandbox-editor' ); ?></h1>
+	<p class="lse-setup-help">
+		<?php esc_html_e( 'Pick what to sync into the sandbox. Defaults match the current behavior.', 'live-sandbox-editor' ); ?>
+	</p>
+
+	<p data-wp-class--lse-hidden="!state.loading"><?php esc_html_e( 'Loading available items…', 'live-sandbox-editor' ); ?></p>
+
+	<div data-wp-class--lse-hidden="!state.loadError">
+		<p><?php esc_html_e( 'Failed to load.', 'live-sandbox-editor' ); ?></p>
+		<button type="button" class="button" data-wp-on--click="actions.retry">
+			<?php esc_html_e( 'Retry', 'live-sandbox-editor' ); ?>
+		</button>
+	</div>
+
+	<div data-wp-class--lse-hidden="state.loading">
+		<fieldset class="lse-setup-group">
+			<legend><?php esc_html_e( 'Plugins', 'live-sandbox-editor' ); ?></legend>
+			<ul>
+				<template data-wp-each--item="state.plugins">
+					<li>
+						<label>
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.togglePlugin">
+							<span data-wp-text="context.item.label"></span>
+						</label>
+					</li>
+				</template>
+			</ul>
+		</fieldset>
+
+		<fieldset class="lse-setup-group">
+			<legend><?php esc_html_e( 'Themes', 'live-sandbox-editor' ); ?></legend>
+			<ul>
+				<template data-wp-each--item="state.themes">
+					<li>
+						<label>
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleTheme">
+							<span data-wp-text="context.item.label"></span>
+						</label>
+					</li>
+				</template>
+			</ul>
+		</fieldset>
+
+		<fieldset class="lse-setup-group">
+			<legend><?php esc_html_e( 'Tables', 'live-sandbox-editor' ); ?></legend>
+			<ul>
+				<template data-wp-each--item="state.tables">
+					<li>
+						<label>
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleTable">
+							<span data-wp-text="context.item.label"></span>
+						</label>
+					</li>
+				</template>
+			</ul>
+		</fieldset>
+
+		<fieldset class="lse-setup-group">
+			<legend><?php esc_html_e( 'Uploads', 'live-sandbox-editor' ); ?></legend>
+			<label>
+				<input type="checkbox" data-wp-bind--checked="state.uploads" data-wp-on--change="actions.toggleUploads">
+				<?php esc_html_e( 'Include wp-content/uploads', 'live-sandbox-editor' ); ?>
+			</label>
+		</fieldset>
+
+		<p>
+			<button type="button" class="button button-primary" data-wp-bind--disabled="state.runDisabled" data-wp-on--click="actions.run">
+				<?php esc_html_e( 'Run', 'live-sandbox-editor' ); ?>
+			</button>
+		</p>
+	</div>
+</div>

--- a/live-sandbox-editor/templates/setup-view.php
+++ b/live-sandbox-editor/templates/setup-view.php
@@ -36,7 +36,7 @@ namespace Live_Sandbox_Editor;
 				<template data-wp-each--item="state.plugins">
 					<li>
 						<label>
-							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.togglePlugin">
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleItem">
 							<span data-wp-text="context.item.label"></span>
 						</label>
 					</li>
@@ -50,7 +50,7 @@ namespace Live_Sandbox_Editor;
 				<template data-wp-each--item="state.themes">
 					<li>
 						<label>
-							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleTheme">
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleItem">
 							<span data-wp-text="context.item.label"></span>
 						</label>
 					</li>
@@ -64,7 +64,7 @@ namespace Live_Sandbox_Editor;
 				<template data-wp-each--item="state.tables">
 					<li>
 						<label>
-							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleTable">
+							<input type="checkbox" data-wp-bind--checked="context.item.selected" data-wp-on--change="actions.toggleItem">
 							<span data-wp-text="context.item.label"></span>
 						</label>
 					</li>

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,10 +6,14 @@ import {
 } from './editor.js';
 import { initFileExplorer } from './file-explorer.js';
 import { readFile, writeFile } from './filesystem.js';
+import type { SyncManifest } from './playground.js';
 import { sandbox } from './store.js';
 import type { OpenFile } from './types.js';
 
-export async function initApp(root: HTMLElement): Promise<void> {
+export async function initApp(
+	root: HTMLElement,
+	manifestOverride?: SyncManifest,
+): Promise<void> {
 	const tabStrip = mustQuery(root, '#lse-tabs');
 	const monacoContainer = mustQuery(root, '#lse-monaco');
 	const fileTreeBody = mustQuery(root, '#lse-file-tree-body');
@@ -66,7 +70,7 @@ export async function initApp(root: HTMLElement): Promise<void> {
 		renderTabs();
 	}
 
-	const client = await sandbox.actions.boot(iframe);
+	const client = await sandbox.actions.boot(iframe, manifestOverride);
 	if (!client) return;
 
 	const docroot = await client.documentRoot;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,38 @@
 import './monaco-environment.js';
 import { initApp } from './app.js';
+import type { SyncManifest } from './playground.js';
+
+function parseManifestParam(): SyncManifest | undefined {
+	const raw = new URLSearchParams(window.location.search).get('manifest');
+	if (!raw) return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		console.warn('[live-sandbox-editor] Ignoring malformed manifest param.');
+		return undefined;
+	}
+	if (
+		!parsed ||
+		typeof parsed !== 'object' ||
+		!Array.isArray((parsed as SyncManifest).plugins) ||
+		!Array.isArray((parsed as SyncManifest).themes) ||
+		!Array.isArray((parsed as SyncManifest).tables) ||
+		typeof (parsed as SyncManifest).uploads !== 'boolean'
+	) {
+		console.warn(
+			'[live-sandbox-editor] Ignoring manifest param with wrong shape.',
+		);
+		return undefined;
+	}
+	return parsed as SyncManifest;
+}
 
 const root = document.getElementById('live-sandbox-editor-root');
 if (!root) {
 	console.error('[live-sandbox-editor] Root element not found.');
 } else {
-	initApp(root).catch((err: unknown) => {
+	initApp(root, parseManifestParam()).catch((err: unknown) => {
 		console.error('[live-sandbox-editor] App init failed:', err);
 	});
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -18,10 +18,12 @@ export interface SyncManifest {
 	uploads: boolean;
 }
 
-interface ManifestResponse {
+export interface ManifestResponse {
 	manifest: SyncManifest;
 	siteUrl: string;
 	uploadsUrl: string;
+	pluginLabels?: Record<string, string>;
+	themeLabels?: Record<string, string>;
 }
 
 async function getErrorResponseText(res: Response): Promise<string | null> {
@@ -37,6 +39,7 @@ export async function initPlayground(
 	iframe: HTMLIFrameElement,
 	onStatus: (status: string) => void,
 	debug: DebugSettings,
+	manifestOverride?: SyncManifest,
 ): Promise<PlaygroundClient> {
 	const debugMode = debug.scriptDebug || debug.wpDebug;
 	const { startPlaygroundWeb } = await import('@wp-playground/client');
@@ -57,13 +60,14 @@ export async function initPlayground(
 
 	onStatus('Resolving sync manifest…');
 	const manifestResp = await fetchManifest();
-	// Future PR: surface a UI for the user to override `manifest` before
-	// kicking off the sync. For now, defaults: active plugins, active
-	// theme + parent, structural WP tables, no uploads.
-	const manifest = manifestResp.manifest;
+	const manifest = manifestOverride ?? manifestResp.manifest;
+	const dbContext: ManifestResponse =
+		manifestOverride !== undefined
+			? { ...manifestResp, manifest }
+			: manifestResp;
 
 	if (debugMode) {
-		console.log('[live-sandbox-editor] manifest:', manifestResp);
+		console.log('[live-sandbox-editor] manifest:', manifest);
 	}
 
 	const hasFiles =
@@ -83,7 +87,7 @@ export async function initPlayground(
 	}
 
 	onStatus('Finalizing sandbox…');
-	await applyPostImportFixups(client, hasDb ? manifestResp : null, onStatus);
+	await applyPostImportFixups(client, hasDb ? dbContext : null, onStatus);
 
 	return client;
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -61,10 +61,7 @@ export async function initPlayground(
 	onStatus('Resolving sync manifest…');
 	const manifestResp = await fetchManifest();
 	const manifest = manifestOverride ?? manifestResp.manifest;
-	const dbContext: ManifestResponse =
-		manifestOverride !== undefined
-			? { ...manifestResp, manifest }
-			: manifestResp;
+	const dbContext: ManifestResponse = { ...manifestResp, manifest };
 
 	if (debugMode) {
 		console.log('[live-sandbox-editor] manifest:', manifest);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -431,11 +431,15 @@ async function applyPostImportFixups(
 
 	// Self-deactivate runs unconditionally — file sync excludes the editor
 	// from copy, but `active_plugins` in the imported DB may still carry it.
+	// Reconciliation runs only when a DB was imported: without one,
+	// Playground's bundled defaults are already self-consistent.
+	const reconcile = dbContext ? 'lse_reconcile_with_filesystem();' : '';
 	await client.run({
 		code: `<?php
 			require '${docroot}/wp-load.php';
 			require_once '${FIXUPS_PATH}';
 			lse_deactivate_self();
+			${reconcile}
 		`,
 	});
 }

--- a/src/post-import-fixups.php
+++ b/src/post-import-fixups.php
@@ -300,6 +300,66 @@ if ( ! function_exists( 'lse_existing_tables' ) ) {
 	}
 }
 
+if ( ! function_exists( 'lse_reconcile_with_filesystem' ) ) {
+	/**
+	 * Drop `active_plugins` entries and switch the active theme when the
+	 * referenced files weren't synced. Otherwise WP boots referencing
+	 * directories that don't exist and emits load errors / 500s.
+	 *
+	 * Driven off the actual sandbox filesystem rather than the original
+	 * manifest, so it's also correct if the sync was partial or the user
+	 * imported a wp_options dump from a different host.
+	 */
+	function lse_reconcile_with_filesystem(): void {
+		$active   = (array) get_option( 'active_plugins', array() );
+		$filtered = array_values(
+			array_filter(
+				$active,
+				static fn( $entry ) => is_string( $entry ) && '' !== $entry && file_exists( WP_PLUGIN_DIR . '/' . $entry )
+			)
+		);
+		if ( $filtered !== $active ) {
+			update_option( 'active_plugins', $filtered );
+		}
+
+		if ( is_multisite() ) {
+			$sitewide = (array) get_site_option( 'active_sitewide_plugins', array() );
+			$kept     = array_filter(
+				$sitewide,
+				static fn( $entry ) => file_exists( WP_PLUGIN_DIR . '/' . $entry ),
+				ARRAY_FILTER_USE_KEY
+			);
+			if ( $kept !== $sitewide ) {
+				update_site_option( 'active_sitewide_plugins', $kept );
+			}
+		}
+
+		$stylesheet    = (string) get_option( 'stylesheet' );
+		$template      = (string) get_option( 'template' );
+		$stylesheet_ok = '' !== $stylesheet && wp_get_theme( $stylesheet )->exists();
+		$template_ok   = '' !== $template && wp_get_theme( $template )->exists();
+		if ( $stylesheet_ok && $template_ok ) {
+			return;
+		}
+		// Fall back to any installed theme — Playground always ships at
+		// least the current core default. `array_keys` is fine here:
+		// `wp_get_themes()` only returns themes whose stylesheets exist.
+		$installed = wp_get_themes( array( 'errors' => null ) );
+		$fallback  = null;
+		foreach ( $installed as $slug => $theme ) {
+			if ( $theme->exists() ) {
+				$fallback = array( $slug, $theme->get_template() );
+				break;
+			}
+		}
+		if ( null === $fallback ) {
+			return;
+		}
+		update_option( 'stylesheet', $fallback[0] );
+		update_option( 'template', $fallback[1] );
+	}
+}
+
 if ( ! function_exists( 'lse_deactivate_self' ) ) {
 	/**
 	 * Match by main-file postfix — the WP plugin dir name isn't stable

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,126 @@
+import { getContext, store } from '@wordpress/interactivity';
+import type { ManifestResponse, SyncManifest } from './playground.js';
+import { getAppData } from './types.js';
+
+const SETUP_MODULE_ID = 'live-sandbox-editor-setup';
+
+interface Item {
+	id: string;
+	label: string;
+	selected: boolean;
+}
+
+interface SetupState {
+	loading: boolean;
+	loadError: boolean;
+	plugins: Item[];
+	themes: Item[];
+	tables: Item[];
+	uploads: boolean;
+	readonly runDisabled: boolean;
+}
+
+interface SetupStore {
+	state: SetupState;
+	actions: {
+		togglePlugin(): void;
+		toggleTheme(): void;
+		toggleTable(): void;
+		toggleUploads(): void;
+		retry(): void;
+		run(): void;
+	};
+}
+
+const setup = store<SetupStore>('live-sandbox-editor/setup', {
+	state: {
+		loading: true,
+		loadError: false,
+		plugins: [],
+		themes: [],
+		tables: [],
+		uploads: false,
+		get runDisabled(): boolean {
+			if (setup.state.loading || setup.state.loadError) return true;
+			const anySelected =
+				setup.state.plugins.some((p) => p.selected) ||
+				setup.state.themes.some((t) => t.selected) ||
+				setup.state.tables.some((t) => t.selected);
+			return !anySelected && !setup.state.uploads;
+		},
+	},
+	actions: {
+		togglePlugin(): void {
+			const ctx = getContext<{ item: Item }>();
+			ctx.item.selected = !ctx.item.selected;
+		},
+		toggleTheme(): void {
+			const ctx = getContext<{ item: Item }>();
+			ctx.item.selected = !ctx.item.selected;
+		},
+		toggleTable(): void {
+			const ctx = getContext<{ item: Item }>();
+			ctx.item.selected = !ctx.item.selected;
+		},
+		toggleUploads(): void {
+			setup.state.uploads = !setup.state.uploads;
+		},
+		retry(): void {
+			void loadDefaults();
+		},
+		run(): void {
+			const manifest: SyncManifest = {
+				plugins: setup.state.plugins.filter((p) => p.selected).map((p) => p.id),
+				themes: setup.state.themes.filter((t) => t.selected).map((t) => t.id),
+				tables: setup.state.tables.filter((t) => t.selected).map((t) => t.id),
+				uploads: setup.state.uploads,
+			};
+			const { runUrl } = getAppData(SETUP_MODULE_ID);
+			const sep = runUrl.includes('?') ? '&' : '?';
+			const url = `${runUrl}${sep}manifest=${encodeURIComponent(
+				JSON.stringify(manifest),
+			)}`;
+			window.location.assign(url);
+		},
+	},
+});
+
+void loadDefaults();
+
+async function loadDefaults(): Promise<void> {
+	setup.state.loading = true;
+	setup.state.loadError = false;
+	const { restUrl, nonce } = getAppData(SETUP_MODULE_ID);
+	try {
+		const res = await fetch(`${restUrl}/sync-manifest`, {
+			headers: { 'X-WP-Nonce': nonce, Accept: 'application/json' },
+		});
+		if (!res.ok) {
+			throw new Error(`sync-manifest failed: ${res.status}`);
+		}
+		const data = (await res.json()) as ManifestResponse;
+		const pluginLabels = data.pluginLabels ?? {};
+		const themeLabels = data.themeLabels ?? {};
+		setup.state.plugins = data.manifest.plugins.map((id) => ({
+			id,
+			label: pluginLabels[id] ?? id,
+			selected: true,
+		}));
+		setup.state.themes = data.manifest.themes.map((id) => ({
+			id,
+			label: themeLabels[id] ?? id,
+			selected: true,
+		}));
+		setup.state.tables = data.manifest.tables.map((id) => ({
+			id,
+			label: id,
+			selected: true,
+		}));
+		setup.state.uploads = data.manifest.uploads;
+		setup.state.loading = false;
+	} catch (err) {
+		console.error('[live-sandbox-editor] Failed to load defaults:', err);
+		setup.state.loadError = true;
+		setup.state.loading = false;
+	}
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -23,9 +23,7 @@ interface SetupState {
 interface SetupStore {
 	state: SetupState;
 	actions: {
-		togglePlugin(): void;
-		toggleTheme(): void;
-		toggleTable(): void;
+		toggleItem(): void;
 		toggleUploads(): void;
 		retry(): void;
 		run(): void;
@@ -50,15 +48,7 @@ const setup = store<SetupStore>('live-sandbox-editor/setup', {
 		},
 	},
 	actions: {
-		togglePlugin(): void {
-			const ctx = getContext<{ item: Item }>();
-			ctx.item.selected = !ctx.item.selected;
-		},
-		toggleTheme(): void {
-			const ctx = getContext<{ item: Item }>();
-			ctx.item.selected = !ctx.item.selected;
-		},
-		toggleTable(): void {
+		toggleItem(): void {
 			const ctx = getContext<{ item: Item }>();
 			ctx.item.selected = !ctx.item.selected;
 		},
@@ -76,11 +66,9 @@ const setup = store<SetupStore>('live-sandbox-editor/setup', {
 				uploads: setup.state.uploads,
 			};
 			const { runUrl } = getAppData(SETUP_MODULE_ID);
-			const sep = runUrl.includes('?') ? '&' : '?';
-			const url = `${runUrl}${sep}manifest=${encodeURIComponent(
-				JSON.stringify(manifest),
-			)}`;
-			window.location.assign(url);
+			const url = new URL(runUrl, window.location.origin);
+			url.searchParams.set('manifest', JSON.stringify(manifest));
+			window.location.assign(url.toString());
 		},
 	},
 });
@@ -92,7 +80,7 @@ async function loadDefaults(): Promise<void> {
 	setup.state.loadError = false;
 	const { restUrl, nonce } = getAppData(SETUP_MODULE_ID);
 	try {
-		const res = await fetch(`${restUrl}/sync-manifest`, {
+		const res = await fetch(`${restUrl}/sync-manifest?labels=1`, {
 			headers: { 'X-WP-Nonce': nonce, Accept: 'application/json' },
 		});
 		if (!res.ok) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { store } from '@wordpress/interactivity';
 import type { PlaygroundClient } from '@wp-playground/client';
-import { initPlayground } from './playground.js';
+import { initPlayground, type SyncManifest } from './playground.js';
 import { getAppData } from './types.js';
 
 export interface SandboxState {
@@ -18,6 +18,7 @@ interface SandboxStore {
 		refresh(): Generator<Promise<unknown>, void>;
 		boot(
 			iframe: HTMLIFrameElement,
+			manifestOverride?: SyncManifest,
 		): Generator<Promise<unknown>, PlaygroundClient | null>;
 	};
 }
@@ -52,6 +53,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		},
 		*boot(
 			iframe: HTMLIFrameElement,
+			manifestOverride?: SyncManifest,
 		): Generator<Promise<unknown>, PlaygroundClient | null> {
 			const { scriptDebug, wpDebug } = getAppData();
 			try {
@@ -61,6 +63,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 						sandbox.state.statusText = s;
 					},
 					{ scriptDebug, wpDebug },
+					manifestOverride,
 				)) as PlaygroundClient;
 			} catch (err) {
 				sandbox.state.statusText = 'Playground failed to initialize.';

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,13 +23,12 @@ export interface AppData {
 	restUrl: string;
 	nonce: string;
 	siteUrl: string;
+	runUrl: string;
 	scriptDebug: boolean;
 	wpDebug: boolean;
 }
 
-export function getAppData(): AppData {
-	const el = document.getElementById(
-		'wp-script-module-data-live-sandbox-editor',
-	);
+export function getAppData(moduleId = 'live-sandbox-editor'): AppData {
+	const el = document.getElementById(`wp-script-module-data-${moduleId}`);
 	return JSON.parse(el?.textContent ?? '{}') as AppData;
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -16,7 +16,10 @@ export default defineConfig({
 		modulePreload: false,
 		sourcemap: true,
 		rolldownOptions: {
-			input: 'src/main.ts',
+			input: {
+				main: 'src/main.ts',
+				setup: 'src/setup.ts',
+			},
 			// `@wordpress/interactivity` is provided at runtime by WordPress
 			// core as a script module; keep the bare specifier in the output
 			// so the host's import map resolves it instead of bundling it.


### PR DESCRIPTION
## Summary

- Splits the plugin into a new top-level **Setup** admin page (checkbox UI to pick which plugins, themes, tables, and uploads to sync) and the existing **Run** page, now a submenu. The Run page accepts the resolved manifest as an optional `?manifest=<json>` query parameter; when absent or malformed it falls back to the existing default-fetching behavior so bookmarks of the bare URL keep working.
- After DB import, reconciles `active_plugins`, `active_sitewide_plugins`, and the active theme against what's actually present on the sandbox filesystem — drops entries whose files weren't synced and switches the active theme to any installed one. Prevents broken sandboxes when a user deselects a plugin/theme but keeps `wp_options`.
- Hook-aware asset enqueueing keyed off a single `page_for_screen()` helper; `script_module_data` filter shared under both module IDs (with new `runUrl`); `/sync-manifest` extended with optional `pluginLabels`/`themeLabels` gated behind `?labels=1` so the run-page boot doesn't pay for `get_plugins()`.
- Build: second Vite entry produces `build/setup.js` alongside `build/main.js`.

## Test plan

- [x] `npm run ci-check` passes (tsgo, biome, vite build, composer validate, php -l, composer lint:src) and produces both `build/main.js` and `build/setup.js`.
- [x] Visit Setup page: sidebar shows "Live Sandbox Editor → Setup / Run". Plugins/themes/tables checkboxes render with display labels, all pre-checked; uploads off; Run enabled.
- [x] Deselect one plugin and click Run: URL becomes `?manifest=<json>`, Playground reaches Ready, the sandbox `wp-content/plugins` directory does not contain the deselected plugin, and `active_plugins` is reconciled (no fatal).
- [x] Visit run page directly with no `manifest` param: boots with default manifest (existing behavior preserved).
- [x] Visit run page with `?manifest=42` (valid JSON, wrong shape): console warning, falls back to defaults.
- [x] Toggle a checkbox on Setup: the unified `toggleItem` action flips state; deselect everything (uploads off): Run button disables.
- [x] Reload a previously-generated `?manifest=` URL: boots with the encoded scope (sharable URLs work).
- [x] Layout fills the viewport on the Run page (regression caught and fixed when the run page moved from top-level to submenu).