### PR TITLE
Fall back to wpdb when pdo_mysql is missing in sync-db

### DIFF
--- a/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
@@ -19,13 +19,60 @@ class Wpdb_Pdo_Adapter {
 	private $wpdb;
 
 	/**
+	 * Mutates the shared mysqli connection on `$wpdb->dbh`: pins its
+	 * charset for the rest of the request so quoting is deterministic.
+	 * The change is not reverted — callers that share this `$wpdb`
+	 * with code that relies on a different charset must coordinate.
+	 *
+	 * Inherits the rest of WordPress's session as-is. wpdb's
+	 * `incompatible_modes` strips the composite `ANSI` mode but not a
+	 * standalone `ANSI_QUOTES`, and `NO_BACKSLASH_ESCAPES` is never set
+	 * by wpdb itself. Either can land in our session via a plugin, a
+	 * site-config hook, or an RDS parameter group, so we re-check both.
+	 *
 	 * @param \wpdb $wpdb wpdb instance whose `dbh` is a mysqli connection.
-	 * @throws \PDOException If `$wpdb->dbh` is not a `\mysqli` instance.
+	 * @throws \PDOException If `$wpdb->dbh` is not a `\mysqli` instance,
+	 *                       if the charset cannot be pinned, if the
+	 *                       `sql_mode` lookup fails, or if the session
+	 *                       runs in a mode the statement parser or
+	 *                       `quote()` is not safe under
+	 *                       (`NO_BACKSLASH_ESCAPES` or `ANSI_QUOTES`).
 	 */
 	public function __construct( \wpdb $wpdb ) {
 		if ( ! ( $wpdb->dbh instanceof \mysqli ) ) {
 			throw new \PDOException( 'Wpdb_Pdo_Adapter requires a mysqli-backed wpdb.' );
 		}
+
+		// Pin the connection charset so `mysqli_real_escape_string()` knows
+		// how to escape multibyte input regardless of how wpdb was set up.
+		$charset = ( isset( $wpdb->charset ) && '' !== $wpdb->charset ) ? $wpdb->charset : 'utf8mb4';
+		// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_set_charset -- intentional: wpdb's $charset reflects the desired connection charset, but on hosts where wpdb didn't get to call set_charset() we still need to pin it so mysqli_real_escape_string() is well-defined.
+		if ( ! \mysqli_set_charset( $wpdb->dbh, $charset ) ) {
+			throw new \PDOException( 'Wpdb_Pdo_Adapter could not set connection charset to ' . $charset . '.' );
+		}
+
+		// Reject session modes that invalidate the assumptions baked into
+		// `quote()` (NO_BACKSLASH_ESCAPES) or the statement parser's
+		// string-literal tracking (ANSI_QUOTES, which makes `"…"` an
+		// identifier delimiter rather than a string literal). Route
+		// through wpdb so the lookup participates in its query accounting.
+		// Use `get_results()` instead of `get_var()` so a legitimately
+		// empty `sql_mode = ''` is not mistaken for a query failure.
+		// Fail closed on real lookup failure — silently skipping the
+		// check would re-open the very vector this guard exists to close.
+		$wpdb->last_error = '';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- intentional: this is a one-shot session-metadata check at adapter construction; caching the value would only hide a sql_mode change made after we last looked.
+		$rows = $wpdb->get_results( 'SELECT @@SESSION.sql_mode', ARRAY_N );
+		if ( '' !== (string) $wpdb->last_error || ! is_array( $rows ) || ! isset( $rows[0][0] ) ) {
+			throw new \PDOException( 'Wpdb_Pdo_Adapter could not read sql_mode for safety check.' );
+		}
+		$mode = (string) $rows[0][0];
+		foreach ( array( 'NO_BACKSLASH_ESCAPES', 'ANSI_QUOTES' ) as $forbidden ) {
+			if ( false !== stripos( $mode, $forbidden ) ) {
+				throw new \PDOException( 'Wpdb_Pdo_Adapter cannot run with ' . $forbidden . ' sql_mode.' );
+			}
+		}
+
 		$this->wpdb = $wpdb;
 	}
 

--- a/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * wpdb-backed PDO adapter for MySQLDumpProducer.
+ *
+ * On hosts with `ext-pdo` but no `pdo_mysql`, `new \PDO('mysql:...')` fails
+ * yet `wpdb` (mysqli) is fully functional. The producer is duck-typed
+ * against PDO, so wrapping `$wpdb` keeps the dump path working.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor;
+
+require_once __DIR__ . '/class-wpdb-pdo-statement.php';
+
+class Wpdb_Pdo_Adapter {
+
+	/** @var \wpdb */
+	private $wpdb;
+
+	/**
+	 * @param \wpdb $wpdb wpdb instance whose `dbh` is a mysqli connection.
+	 * @throws \PDOException If `$wpdb->dbh` is not a `\mysqli` instance.
+	 */
+	public function __construct( \wpdb $wpdb ) {
+		if ( ! ( $wpdb->dbh instanceof \mysqli ) ) {
+			throw new \PDOException( 'Wpdb_Pdo_Adapter requires a mysqli-backed wpdb.' );
+		}
+		$this->wpdb = $wpdb;
+	}
+
+	public function prepare( string $sql ): Wpdb_Pdo_Statement {
+		return new Wpdb_Pdo_Statement( $this->wpdb, $this, $sql );
+	}
+
+	public function query( string $sql ): Wpdb_Pdo_Statement {
+		$stmt = new Wpdb_Pdo_Statement( $this->wpdb, $this, $sql );
+		$stmt->execute();
+		return $stmt;
+	}
+
+	/**
+	 * Quote a value byte-equivalent to `\PDO::quote()` against the mysql
+	 * driver. Bypasses `wpdb::esc_sql()` / `wpdb::_real_escape()` because
+	 * both feed their output through `wpdb::add_placeholder_escape()`, which
+	 * substitutes `%` with a sentinel meant to be stripped by
+	 * `wpdb::prepare()`. Since this adapter never calls `prepare()`, those
+	 * sentinels would leak into the dumped SQL.
+	 *
+	 * @param mixed $value Scalar or null to quote.
+	 */
+	public function quote( $value ): string {
+		if ( null === $value ) {
+			return 'NULL';
+		}
+		if ( is_bool( $value ) ) {
+			// PDO's mysql driver emits '1' / '' for true / false — match it.
+			return $value ? "'1'" : "''";
+		}
+		// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_real_escape_string -- intentional: we need PDO::quote() byte-equivalence, which wpdb's escape wrappers cannot provide.
+		$escaped = \mysqli_real_escape_string( $this->wpdb->dbh, (string) $value );
+		return "'" . $escaped . "'";
+	}
+
+	/**
+	 * @throws \PDOException Always — surfaces unimplemented producer calls
+	 *                       through the existing PDOException handlers.
+	 */
+	public function __call( string $name, array $args ) {
+		throw new \PDOException( 'Wpdb_Pdo_Adapter does not implement ' . $name . '()' );
+	}
+}

--- a/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
@@ -39,6 +39,13 @@ class Wpdb_Pdo_Statement {
 	 * run through wpdb. Calling `wpdb::prepare()` here would re-escape the
 	 * already-quoted values and reprocess `%` characters.
 	 *
+	 * Mutates the shared `$GLOBALS['wpdb']`: clears `last_error` before the
+	 * query and calls `flush()` after, so unrelated request-scope consumers
+	 * (debug bars, `shutdown` callbacks) will see those fields reset.
+	 * Note: under `SAVEQUERIES` (dev/staging only), `wpdb::flush()` does
+	 * NOT clear `$wpdb->queries`, so a long dump will still grow that
+	 * array. Production has `SAVEQUERIES` off; no action needed there.
+	 *
 	 * @param array<int|string,mixed>|null $params Positional or named params.
 	 * @throws \PDOException If wpdb reports an error or the query fails.
 	 */
@@ -81,14 +88,27 @@ class Wpdb_Pdo_Statement {
 	 * Emits the result into one freshly built buffer so the source SQL is
 	 * walked exactly once and no intermediate copies are made.
 	 *
-	 * @param array<int|string,mixed> $params Positional and/or named params.
+	 * Supported SQL subset (matches what `MySQLDumpProducer` emits):
+	 *   - `'…'` and `"…"` string literals are tracked as opaque regions.
+	 *   - `` `…` `` backtick-quoted identifiers are tracked as opaque
+	 *     regions, so a `?` inside `` `weird?col` `` does not consume a
+	 *     positional param.
+	 *   - Positional `?` substituted in document order; named `:name`
+	 *     substituted via longest-key-first match.
+	 *   - Escaped quotes (`\'`, `''`, `""`) inside literals and SQL
+	 *     comments (`--`, `#`, `/* … *\/`) are NOT modeled — the
+	 *     producer does not emit them in prepared statements.
+	 *
+	 * @param array<int|string,mixed> $params Positional (0-based) and/or
+	 *                                        named params.
 	 */
 	private function substitute_placeholders( string $sql, array $params ): string {
-		$out       = '';
-		$len       = strlen( $sql );
-		$in_single = false;
-		$in_double = false;
-		$pos_idx   = 0;
+		$out         = '';
+		$len         = strlen( $sql );
+		$in_single   = false;
+		$in_double   = false;
+		$in_backtick = false;
+		$pos_idx     = 0;
 		// Sort named keys longest-first so `:id` cannot eat `:id2`.
 		$named = array();
 		foreach ( $params as $key => $value ) {
@@ -120,6 +140,13 @@ class Wpdb_Pdo_Statement {
 				}
 				continue;
 			}
+			if ( $in_backtick ) {
+				$out .= $ch;
+				if ( '`' === $ch ) {
+					$in_backtick = false;
+				}
+				continue;
+			}
 			if ( "'" === $ch ) {
 				$in_single = true;
 				$out      .= $ch;
@@ -128,6 +155,11 @@ class Wpdb_Pdo_Statement {
 			if ( '"' === $ch ) {
 				$in_double = true;
 				$out      .= $ch;
+				continue;
+			}
+			if ( '`' === $ch ) {
+				$in_backtick = true;
+				$out        .= $ch;
 				continue;
 			}
 			if ( '?' === $ch ) {
@@ -183,7 +215,10 @@ class Wpdb_Pdo_Statement {
 	}
 
 	/**
-	 * @param int|string $parameter Positional index or `:name`.
+	 * @param int|string $parameter 1-based positional index (per PDO) or
+	 *                              `:name`. Stored at `$parameter - 1` for
+	 *                              integer keys so `execute()`'s 0-based
+	 *                              positional walk lands on the same value.
 	 * @param mixed      $value     Value to bind.
 	 * @param int        $type      PDO param type — ignored: `quote()` infers
 	 *                              from the PHP type and the producer never
@@ -193,7 +228,8 @@ class Wpdb_Pdo_Statement {
 		if ( null === $this->bound_params ) {
 			$this->bound_params = array();
 		}
-		$this->bound_params[ $parameter ] = $value;
+		$key = is_int( $parameter ) ? $parameter - 1 : $parameter;
+		$this->bound_params[ $key ] = $value;
 		return true;
 	}
 

--- a/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Statement-side wrapper for `Wpdb_Pdo_Adapter`. Eagerly loads result rows
+ * on `execute()` and serves them through `fetch()` / `fetchColumn()`.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor;
+
+class Wpdb_Pdo_Statement {
+
+	/** @var \wpdb */
+	private $wpdb;
+
+	/** @var Wpdb_Pdo_Adapter */
+	private $adapter;
+
+	/** @var string */
+	private $sql;
+
+	/** @var array<int,array<string,mixed>> */
+	private $rows = array();
+
+	/** @var int */
+	private $position = 0;
+
+	/** @var array<int|string,mixed>|null */
+	private $bound_params = null;
+
+	public function __construct( \wpdb $wpdb, Wpdb_Pdo_Adapter $adapter, string $sql ) {
+		$this->wpdb    = $wpdb;
+		$this->adapter = $adapter;
+		$this->sql     = $sql;
+	}
+
+	/**
+	 * Substitute `?` and `:name` placeholders via the adapter's `quote()` and
+	 * run through wpdb. Calling `wpdb::prepare()` here would re-escape the
+	 * already-quoted values and reprocess `%` characters.
+	 *
+	 * @param array<int|string,mixed>|null $params Positional or named params.
+	 * @throws \PDOException If wpdb reports an error or the query fails.
+	 */
+	public function execute( ?array $params = null ): bool {
+		if ( null === $params && null !== $this->bound_params ) {
+			$params = $this->bound_params;
+		}
+
+		$sql = ( null !== $params && count( $params ) > 0 )
+			? $this->substitute_placeholders( $this->sql, $params )
+			: $this->sql;
+
+		// wpdb does not throw — clear last_error first so we can detect a
+		// fresh failure even when get_results returns an empty array.
+		$this->wpdb->last_error = '';
+		try {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- placeholders already substituted via PDO::quote()-equivalent escaping above; calling wpdb::prepare() here would corrupt the SQL.
+			$result = $this->wpdb->get_results( $sql, ARRAY_A );
+
+			if ( '' !== (string) $this->wpdb->last_error ) {
+				throw new \PDOException( $this->wpdb->last_error );
+			}
+			if ( ! is_array( $result ) ) {
+				throw new \PDOException( 'wpdb query failed.' );
+			}
+
+			$this->rows     = $result;
+			$this->position = 0;
+		} finally {
+			// wpdb otherwise retains last_result for the rest of the request,
+			// which compounds memory pressure across 250-row BLOB batches.
+			$this->wpdb->flush();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Single forward-pass placeholder substitution skipping string literals.
+	 * Emits the result into one freshly built buffer so the source SQL is
+	 * walked exactly once and no intermediate copies are made.
+	 *
+	 * @param array<int|string,mixed> $params Positional and/or named params.
+	 */
+	private function substitute_placeholders( string $sql, array $params ): string {
+		$out       = '';
+		$len       = strlen( $sql );
+		$in_single = false;
+		$in_double = false;
+		$pos_idx   = 0;
+		// Sort named keys longest-first so `:id` cannot eat `:id2`.
+		$named = array();
+		foreach ( $params as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$named[ $key ] = $value;
+			}
+		}
+		uksort(
+			$named,
+			static function ( $a, $b ) {
+				return strlen( $b ) - strlen( $a );
+			}
+		);
+
+		for ( $i = 0; $i < $len; $i++ ) {
+			$ch = $sql[ $i ];
+
+			if ( $in_single ) {
+				$out .= $ch;
+				if ( "'" === $ch ) {
+					$in_single = false;
+				}
+				continue;
+			}
+			if ( $in_double ) {
+				$out .= $ch;
+				if ( '"' === $ch ) {
+					$in_double = false;
+				}
+				continue;
+			}
+			if ( "'" === $ch ) {
+				$in_single = true;
+				$out      .= $ch;
+				continue;
+			}
+			if ( '"' === $ch ) {
+				$in_double = true;
+				$out      .= $ch;
+				continue;
+			}
+			if ( '?' === $ch ) {
+				if ( array_key_exists( $pos_idx, $params ) ) {
+					$out .= $this->adapter->quote( $params[ $pos_idx ] );
+				} else {
+					$out .= $ch;
+				}
+				++$pos_idx;
+				continue;
+			}
+			if ( ':' === $ch && ! empty( $named ) ) {
+				$matched = false;
+				foreach ( $named as $key => $value ) {
+					$klen = strlen( $key );
+					if ( substr( $sql, $i, $klen ) === $key ) {
+						$out    .= $this->adapter->quote( $value );
+						$i      += $klen - 1;
+						$matched = true;
+						break;
+					}
+				}
+				if ( $matched ) {
+					continue;
+				}
+			}
+			$out .= $ch;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array<string,mixed>|false Next row, or false when exhausted.
+	 */
+	public function fetch( int $mode = \PDO::FETCH_ASSOC ) {
+		if ( $this->position >= count( $this->rows ) ) {
+			return false;
+		}
+		return $this->rows[ $this->position++ ];
+	}
+
+	/**
+	 * @return mixed|false
+	 */
+	public function fetchColumn( int $column_number = 0 ) {
+		$row = $this->fetch();
+		if ( false === $row ) {
+			return false;
+		}
+		$values = array_values( $row );
+		return $values[ $column_number ] ?? false;
+	}
+
+	/**
+	 * @param int|string $parameter Positional index or `:name`.
+	 * @param mixed      $value     Value to bind.
+	 * @param int        $type      PDO param type — ignored: `quote()` infers
+	 *                              from the PHP type and the producer never
+	 *                              reads it back.
+	 */
+	public function bindValue( $parameter, $value, int $type = \PDO::PARAM_STR ): bool {
+		if ( null === $this->bound_params ) {
+			$this->bound_params = array();
+		}
+		$this->bound_params[ $parameter ] = $value;
+		return true;
+	}
+
+	/**
+	 * @throws \PDOException Always.
+	 */
+	public function __call( string $name, array $args ) {
+		throw new \PDOException( 'Wpdb_Pdo_Statement does not implement ' . $name . '()' );
+	}
+}

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -26,6 +26,7 @@ const VERSION    = '0.1';
 
 require_once __DIR__ . '/inc/sync-stream.php';
 require_once __DIR__ . '/inc/manifest.php';
+require_once __DIR__ . '/inc/class-wpdb-pdo-adapter.php';
 
 /**
  * Load vendored Reprint classes only if they are not already defined.
@@ -475,21 +476,25 @@ function rest_sync_db( WP_REST_Request $request ): void {
 	}
 
 	try {
-		// build_pdo_dsn() is provided by reprint-exporter's Composer `files`
-		// autoload; static analysers can't see it.
-		if ( function_exists( 'build_pdo_dsn' ) ) {
-			$dsn = build_pdo_dsn( DB_HOST, DB_NAME );
+		if ( extension_loaded( 'pdo_mysql' ) ) {
+			// build_pdo_dsn() is provided by reprint-exporter's Composer `files`
+			// autoload; static analysers can't see it.
+			if ( function_exists( 'build_pdo_dsn' ) ) {
+				$dsn = build_pdo_dsn( DB_HOST, DB_NAME );
+			} else {
+				$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+			}
+			// phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO -- raw PDO is the preferred dump connection when pdo_mysql is loaded; the wpdb adapter is the fallback for hosts without it.
+			$db = new \PDO(
+				$dsn,
+				DB_USER,
+				DB_PASSWORD,
+				array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
+			);
+			// phpcs:enable WordPress.DB.RestrictedClasses.mysql__PDO
 		} else {
-			$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+			$db = new Wpdb_Pdo_Adapter( $GLOBALS['wpdb'] );
 		}
-		// phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO -- $wpdb can't enumerate tables for the dumper; raw PDO is intentional here.
-		$pdo = new \PDO(
-			$dsn,
-			DB_USER,
-			DB_PASSWORD,
-			array( \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION )
-		);
-		// phpcs:enable WordPress.DB.RestrictedClasses.mysql__PDO
 	} catch ( \PDOException $e ) {
 		http_response_code( 500 );
 		Sync_Stream\emit_marker( Sync_Stream\MARKER_ERR, 'db_connect: ' . $e->getMessage() );
@@ -498,7 +503,7 @@ function rest_sync_db( WP_REST_Request $request ): void {
 	}
 
 	$producer = new MySQLDumpProducer(
-		$pdo,
+		$db,
 		array( 'tables_to_process' => $manifest['tables'] )
 	);
 	$encoder  = new Sync_Stream\B64_Streamer();


### PR DESCRIPTION
The reprint-exporter MySQLDumpProducer is duck-typed against PDO; on
hosts with ext-pdo but no pdo_mysql, raw PDO construction fails while
wpdb (mysqli) still works. `rest_sync_db()` now picks `Wpdb_Pdo_Adapter`
when `pdo_mysql` is missing, keeping the dump path working on those
hosts. Verified end-to-end against a wp-env image with `pdo_mysql`
disabled.