### PR TITLE
List all installed plugins/themes in Setup

### DIFF
--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -281,27 +281,31 @@ function rest_sync_manifest( WP_REST_Request $request ): array {
 		'uploadsUrl' => $uploads_url,
 	);
 
-	// Display labels are only used by the Setup view. Computing them
-	// requires walking every installed plugin via `get_plugins()`, so
-	// callers opt in with `?labels=1` to keep the run-page boot cheap.
+	// Available items + display labels are only used by the Setup view.
+	// Computing them requires walking every installed plugin via
+	// `get_plugins()`, so callers opt in with `?labels=1` to keep the
+	// run-page boot cheap. The label maps double as the universe of
+	// available items for the Setup checkbox lists; the `manifest` field
+	// continues to mean "active by default".
 	if ( ! $request->get_param( 'labels' ) ) {
 		return $response;
 	}
 
 	// `get_plugins()` is admin-only and not autoloaded for REST callbacks.
 	require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	$all_plugins   = get_plugins();
 	$plugin_labels = array();
-	foreach ( $manifest['plugins'] as $entry ) {
-		$plugin_labels[ $entry ] = isset( $all_plugins[ $entry ]['Name'] )
-			? (string) $all_plugins[ $entry ]['Name']
-			: $entry;
+	foreach ( get_plugins() as $entry => $data ) {
+		if ( Manifest\is_self_plugin_entry( $entry ) ) {
+			continue;
+		}
+		$name                    = isset( $data['Name'] ) ? (string) $data['Name'] : '';
+		$plugin_labels[ $entry ] = '' !== $name ? $name : $entry;
 	}
 
 	$theme_labels = array();
-	foreach ( $manifest['themes'] as $slug ) {
-		$theme                 = wp_get_theme( $slug );
-		$name                  = $theme->exists() ? (string) $theme->get( 'Name' ) : $slug;
+	foreach ( wp_get_themes() as $slug => $theme ) {
+		$slug                  = (string) $slug;
+		$name                  = (string) $theme->get( 'Name' );
 		$theme_labels[ $slug ] = '' !== $name ? $name : $slug;
 	}
 

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -281,12 +281,8 @@ function rest_sync_manifest( WP_REST_Request $request ): array {
 		'uploadsUrl' => $uploads_url,
 	);
 
-	// Available items + display labels are only used by the Setup view.
-	// Computing them requires walking every installed plugin via
-	// `get_plugins()`, so callers opt in with `?labels=1` to keep the
-	// run-page boot cheap. The label maps double as the universe of
-	// available items for the Setup checkbox lists; the `manifest` field
-	// continues to mean "active by default".
+	// Setup-only: walking every installed plugin/theme is opt-in via
+	// `?labels=1` so the run-page boot stays cheap.
 	if ( ! $request->get_param( 'labels' ) ) {
 		return $response;
 	}
@@ -304,9 +300,8 @@ function rest_sync_manifest( WP_REST_Request $request ): array {
 
 	$theme_labels = array();
 	foreach ( wp_get_themes() as $slug => $theme ) {
-		$slug                  = (string) $slug;
-		$name                  = (string) $theme->get( 'Name' );
-		$theme_labels[ $slug ] = '' !== $name ? $name : $slug;
+		$name                          = (string) $theme->get( 'Name' );
+		$theme_labels[ (string) $slug ] = '' !== $name ? $name : (string) $slug;
 	}
 
 	$response['pluginLabels'] = $plugin_labels;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -99,10 +99,7 @@ async function loadDefaults(): Promise<void> {
 			throw new Error(`sync-manifest failed: ${res.status}`);
 		}
 		const data = (await res.json()) as ManifestResponse;
-		setup.state.plugins = buildItems(
-			data.pluginLabels,
-			data.manifest.plugins,
-		);
+		setup.state.plugins = buildItems(data.pluginLabels, data.manifest.plugins);
 		setup.state.themes = buildItems(data.themeLabels, data.manifest.themes);
 		setup.state.tables = data.manifest.tables.map((id) => ({
 			id,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -75,6 +75,18 @@ const setup = store<SetupStore>('live-sandbox-editor/setup', {
 
 void loadDefaults();
 
+function buildItems(
+	labels: Record<string, string> | undefined,
+	active: string[],
+): Item[] {
+	const activeSet = new Set(active);
+	return Object.entries(labels ?? {})
+		.map(([id, label]) => ({ id, label, selected: activeSet.has(id) }))
+		.sort((a, b) =>
+			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+		);
+}
+
 async function loadDefaults(): Promise<void> {
 	setup.state.loading = true;
 	setup.state.loadError = false;
@@ -87,26 +99,11 @@ async function loadDefaults(): Promise<void> {
 			throw new Error(`sync-manifest failed: ${res.status}`);
 		}
 		const data = (await res.json()) as ManifestResponse;
-		const pluginLabels = data.pluginLabels ?? {};
-		const themeLabels = data.themeLabels ?? {};
-		const activePlugins = new Set(data.manifest.plugins);
-		const activeThemes = new Set(data.manifest.themes);
-		const byLabel = (a: Item, b: Item): number =>
-			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
-		setup.state.plugins = Object.entries(pluginLabels)
-			.map(([id, label]) => ({
-				id,
-				label,
-				selected: activePlugins.has(id),
-			}))
-			.sort(byLabel);
-		setup.state.themes = Object.entries(themeLabels)
-			.map(([id, label]) => ({
-				id,
-				label,
-				selected: activeThemes.has(id),
-			}))
-			.sort(byLabel);
+		setup.state.plugins = buildItems(
+			data.pluginLabels,
+			data.manifest.plugins,
+		);
+		setup.state.themes = buildItems(data.themeLabels, data.manifest.themes);
 		setup.state.tables = data.manifest.tables.map((id) => ({
 			id,
 			label: id,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -89,16 +89,24 @@ async function loadDefaults(): Promise<void> {
 		const data = (await res.json()) as ManifestResponse;
 		const pluginLabels = data.pluginLabels ?? {};
 		const themeLabels = data.themeLabels ?? {};
-		setup.state.plugins = data.manifest.plugins.map((id) => ({
-			id,
-			label: pluginLabels[id] ?? id,
-			selected: true,
-		}));
-		setup.state.themes = data.manifest.themes.map((id) => ({
-			id,
-			label: themeLabels[id] ?? id,
-			selected: true,
-		}));
+		const activePlugins = new Set(data.manifest.plugins);
+		const activeThemes = new Set(data.manifest.themes);
+		const byLabel = (a: Item, b: Item): number =>
+			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+		setup.state.plugins = Object.entries(pluginLabels)
+			.map(([id, label]) => ({
+				id,
+				label,
+				selected: activePlugins.has(id),
+			}))
+			.sort(byLabel);
+		setup.state.themes = Object.entries(themeLabels)
+			.map(([id, label]) => ({
+				id,
+				label,
+				selected: activeThemes.has(id),
+			}))
+			.sort(byLabel);
 		setup.state.tables = data.manifest.tables.map((id) => ({
 			id,
 			label: id,


### PR DESCRIPTION
## Summary
- The Setup view previously only listed active plugins/themes, hiding the option to scope inactive items into the sandbox.
- `/sync-manifest?labels=1` now returns labels for every installed plugin (excluding self) and every installed theme; the `manifest` field still carries the active items.
- `setup.ts` builds checkbox lists from the full label maps and seeds `selected` from the active manifest, sorted by label.

## Test plan
- [ ] Open Live Sandbox Editor → Setup on a site with several inactive plugins and themes.
- [ ] Confirm every installed plugin and theme appears in its respective list.
- [ ] Confirm only the active plugins / current stylesheet + template are checked by default.
- [ ] Toggle a few items and click Run; verify the resulting `?manifest=…` reflects the selections.