### PR TITLE
Lift URL toolbar full-width, defer Monaco until editor opens

### DIFF
--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -107,6 +107,7 @@ function enqueue_assets( string $hook_suffix ): void {
 			'url'        => '',
 			'statusText' => 'Initializing…',
 			'isReady'    => false,
+			'editorOpen' => false,
 		)
 	);
 

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -48,9 +48,10 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	overflow: hidden;
 }
 
-/* Editor pane: file tree + Monaco */
+/* Editor pane: file tree + Monaco. Hidden by default; .lse-main.editor-open
+   re-enables it. */
 .lse-editor-pane {
-	display: flex;
+	display: none;
 	flex: 1;
 	min-width: 0;
 	overflow: hidden;
@@ -157,28 +158,44 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	flex: 1;
 }
 
-/* Drag handle */
+/* Drag handle (hidden by default; shown when editor is open) */
 .lse-drag-handle {
 	width: 4px;
 	background: #3c3c3c;
 	cursor: col-resize;
 	flex-shrink: 0;
+	display: none;
 }
 
 .lse-drag-handle:hover {
 	background: #007acc;
 }
 
-/* Preview pane */
+/* Preview pane fills the row when the editor is closed. */
 .lse-preview-pane {
-	width: 40%;
-	min-width: 280px;
-	flex-shrink: 0;
+	flex: 1;
+	min-width: 0;
 	display: flex;
 	flex-direction: column;
 }
 
-.lse-preview-toolbar {
+/* When the editor is open, restore the default split layout. */
+.lse-main.editor-open .lse-editor-pane {
+	display: flex;
+}
+
+.lse-main.editor-open .lse-drag-handle {
+	display: block;
+}
+
+.lse-main.editor-open .lse-preview-pane {
+	flex: 0 0 auto;
+	width: 40%;
+	min-width: 280px;
+}
+
+/* Top toolbar (full width, lifted from the preview pane). */
+.lse-toolbar {
 	min-height: 36px;
 	background: #2d2d2d;
 	border-bottom: 1px solid #3c3c3c;
@@ -200,6 +217,19 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	font-size: 14px;
 	line-height: 1;
 	flex-shrink: 0;
+}
+
+.lse-toolbar-btn .dashicons {
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	vertical-align: -3px;
+}
+
+.lse-toolbar-btn[aria-pressed="true"] {
+	background: #094771;
+	color: #fff;
+	border-color: #094771;
 }
 
 .lse-toolbar-btn:hover {

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -52,7 +52,7 @@ namespace Live_Sandbox_Editor;
 	<div
 		class="lse-main"
 		data-wp-class--editor-open="state.editorOpen"
-		data-wp-watch--editor="callbacks.onEditorOpenChange"
+		data-wp-watch="callbacks.onEditorOpenChange"
 	>
 		<div class="lse-editor-pane">
 			<div class="lse-file-tree">

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -16,11 +16,48 @@ namespace Live_Sandbox_Editor;
 
 ?>
 <div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox">
-	<div class="lse-main">
+	<div class="lse-toolbar">
+		<button
+			type="button"
+			class="lse-toolbar-btn"
+			data-wp-on--click="actions.toggleEditor"
+			data-wp-bind--disabled="state.notReady"
+			data-wp-bind--aria-pressed="state.editorOpen"
+			disabled
+			aria-label="Toggle code editor"
+		><span class="dashicons dashicons-editor-code" aria-hidden="true"></span></button>
+		<button
+			type="button"
+			class="lse-toolbar-btn"
+			data-wp-on--click="actions.refresh"
+			data-wp-bind--disabled="state.notReady"
+			disabled
+			aria-label="Refresh"
+		>↺</button>
+		<form class="lse-url-form" data-wp-on--submit="actions.navigate">
+			<input
+				type="text"
+				class="lse-url-input"
+				placeholder="/wp-admin/"
+				data-wp-bind--value="state.url"
+				data-wp-bind--disabled="state.notReady"
+				data-wp-on--input="actions.setUrl"
+				aria-label="URL to visit in the playground"
+				autocomplete="off"
+				spellcheck="false"
+				disabled
+			>
+		</form>
+	</div>
+	<div
+		class="lse-main"
+		data-wp-class--editor-open="state.editorOpen"
+		data-wp-watch--editor="callbacks.onEditorOpenChange"
+	>
 		<div class="lse-editor-pane">
 			<div class="lse-file-tree">
 				<div class="lse-file-tree-header">Files</div>
-				<div id="lse-file-tree-body" class="lse-file-tree-body"></div>
+				<div id="lse-file-tree-body" class="lse-file-tree-body" tabindex="-1"></div>
 			</div>
 			<div class="lse-monaco-section">
 				<div id="lse-tabs" class="lse-tabs"></div>
@@ -29,31 +66,6 @@ namespace Live_Sandbox_Editor;
 		</div>
 		<div id="lse-drag-handle" class="lse-drag-handle"></div>
 		<div class="lse-preview-pane">
-			<div class="lse-preview-toolbar">
-				<button
-					type="button"
-					class="lse-toolbar-btn"
-					data-wp-on--click="actions.refresh"
-					data-wp-bind--disabled="state.notReady"
-					disabled
-					title="Refresh"
-					aria-label="Refresh"
-				>↺</button>
-				<form class="lse-url-form" data-wp-on--submit="actions.navigate">
-					<input
-						type="text"
-						class="lse-url-input"
-						placeholder="/wp-admin/"
-						data-wp-bind--value="state.url"
-						data-wp-bind--disabled="state.notReady"
-						data-wp-on--input="actions.setUrl"
-						aria-label="URL to visit in the playground"
-						autocomplete="off"
-						spellcheck="false"
-						disabled
-					>
-				</form>
-			</div>
 			<iframe id="lse-preview-iframe" class="lse-preview-iframe" allow="cross-origin-isolated"></iframe>
 		</div>
 	</div>

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,11 @@
-import {
-	addSaveCommand,
-	initEditor,
-	loadFileIntoEditor,
-	showInEditor,
-} from './editor.js';
+import { store } from '@wordpress/interactivity';
 import { initFileExplorer } from './file-explorer.js';
 import { readFile, writeFile } from './filesystem.js';
 import type { SyncManifest } from './playground.js';
 import { sandbox } from './store.js';
 import type { OpenFile } from './types.js';
+
+type EditorMod = typeof import('./editor.js');
 
 export async function initApp(
 	root: HTMLElement,
@@ -22,13 +19,12 @@ export async function initApp(
 	const previewPane = mustQuery(root, '.lse-preview-pane');
 	const iframe = mustQuery(root, '#lse-preview-iframe') as HTMLIFrameElement;
 
-	initEditor(monacoContainer);
 	initDragHandle(dragHandle, editorPane, previewPane);
 
 	const openTabs: OpenFile[] = [];
 	let activeTab: string | null = null;
 
-	function renderTabs(): void {
+	function renderTabs(mod: EditorMod): void {
 		tabStrip.replaceChildren();
 		for (const tab of openTabs) {
 			const tabEl = el('div', 'lse-tab');
@@ -44,53 +40,88 @@ export async function initApp(
 			tabEl.appendChild(labelEl);
 			tabEl.appendChild(closeBtn);
 
-			tabEl.addEventListener('click', () => activateTab(tab.path));
+			tabEl.addEventListener('click', () => activateTab(tab.path, mod));
 			closeBtn.addEventListener('click', (e) => {
 				e.stopPropagation();
-				closeTab(tab.path);
+				closeTab(tab.path, mod);
 			});
 
 			tabStrip.appendChild(tabEl);
 		}
 	}
 
-	function activateTab(path: string): void {
+	function activateTab(path: string, mod: EditorMod): void {
 		activeTab = path;
-		showInEditor(path);
-		renderTabs();
+		mod.showInEditor(path);
+		renderTabs(mod);
 	}
 
-	function closeTab(path: string): void {
+	function closeTab(path: string, mod: EditorMod): void {
 		const idx = openTabs.findIndex((t) => t.path === path);
 		openTabs.splice(idx, 1);
 		if (activeTab === path) {
 			activeTab = openTabs[idx]?.path ?? openTabs[idx - 1]?.path ?? null;
-			showInEditor(activeTab);
+			mod.showInEditor(activeTab);
 		}
-		renderTabs();
+		renderTabs(mod);
 	}
+
+	let saveHandler: ((path: string, content: string) => Promise<void>) | null =
+		null;
+
+	let editorLoadPromise: Promise<EditorMod> | null = null;
+	function ensureEditorLoaded(): Promise<EditorMod> {
+		if (!editorLoadPromise) {
+			editorLoadPromise = (async () => {
+				// editor.js side-effect-imports monaco-environment.js, so
+				// MonacoEnvironment is registered before monaco.editor.create().
+				const mod = await import('./editor.js');
+				mod.initEditor(monacoContainer);
+				if (saveHandler) mod.addSaveCommand(saveHandler);
+				// Belt-and-suspenders: Monaco's automaticLayout ResizeObserver
+				// can lag a frame on first reveal of a previously-hidden
+				// container; force a sync layout against real dims.
+				requestAnimationFrame(() => mod.getEditor()?.layout());
+				return mod;
+			})();
+		}
+		return editorLoadPromise;
+	}
+
+	// Register the data-wp-watch callback synchronously, before the boot
+	// await — so any toggle click after hydration finds it. The
+	// Interactivity API's store() merges successive registrations to the
+	// same namespace.
+	store('live-sandbox-editor/sandbox', {
+		callbacks: {
+			*onEditorOpenChange(): Generator<Promise<unknown>, void> {
+				if (sandbox.state.editorOpen) {
+					yield ensureEditorLoaded();
+					fileTreeBody.focus();
+				} else {
+					// Clear inline widths set by the drag handle: their
+					// `width:Npx` would otherwise pin the preview pane to its
+					// dragged width when the editor pane is hidden, leaving an
+					// empty gap where the editor used to be.
+					editorPane.style.cssText = '';
+					previewPane.style.cssText = '';
+					const btn = root.querySelector<HTMLElement>(
+						'[data-wp-on--click="actions.toggleEditor"]',
+					);
+					btn?.focus();
+				}
+			},
+		},
+	});
 
 	const client = await sandbox.actions.boot(iframe, manifestOverride);
 	if (!client) return;
 
-	const docroot = await client.documentRoot;
-	const wpContentPath = `${docroot}/wp-content`;
-
-	initFileExplorer(fileTreeBody, client, wpContentPath, async (filePath) => {
-		const existingTab = openTabs.find((t) => t.path === filePath);
-		const label = filePath.split('/').pop() ?? filePath;
-
-		if (!existingTab) {
-			const content = await readFile(client, filePath);
-			openTabs.push({ path: filePath, label });
-			loadFileIntoEditor(filePath, content);
-		}
-
-		activateTab(filePath);
-		sandbox.state.statusText = filePath;
-	});
-
-	addSaveCommand(async (path, content) => {
+	// Assign saveHandler before any further awaits — closes a window where
+	// a toggle click between boot resolving and saveHandler being set could
+	// run ensureEditorLoaded with a null saveHandler and leave Cmd-S
+	// unregistered.
+	saveHandler = async (path, content) => {
 		await writeFile(client, path, content);
 		const currentUrl = await client.getCurrentURL();
 		await client.goTo(currentUrl);
@@ -101,6 +132,24 @@ export async function initApp(
 				sandbox.state.statusText = 'Ready';
 			}
 		}, 2000);
+	};
+
+	const docroot = await client.documentRoot;
+	const wpContentPath = `${docroot}/wp-content`;
+
+	initFileExplorer(fileTreeBody, client, wpContentPath, async (filePath) => {
+		const mod = await ensureEditorLoaded();
+		const existingTab = openTabs.find((t) => t.path === filePath);
+		const label = filePath.split('/').pop() ?? filePath;
+
+		if (!existingTab) {
+			const content = await readFile(client, filePath);
+			openTabs.push({ path: filePath, label });
+			mod.loadFileIntoEditor(filePath, content);
+		}
+
+		activateTab(filePath, mod);
+		sandbox.state.statusText = filePath;
 	});
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,7 +77,15 @@ export async function initApp(
 				// MonacoEnvironment is registered before monaco.editor.create().
 				const mod = await import('./editor.js');
 				mod.initEditor(monacoContainer);
-				if (saveHandler) mod.addSaveCommand(saveHandler);
+				// Always register the save command. The wrapper resolves
+				// `saveHandler` at Cmd-S press time, so initialising the
+				// editor before `saveHandler` is assigned (toggle clicked
+				// during the gap between `state.isReady` flipping and
+				// `boot()` resolving) is safe — Cmd-S no-ops until the
+				// handler lands instead of permanently losing the binding.
+				mod.addSaveCommand((path, content) => {
+					saveHandler?.(path, content);
+				});
 				// Belt-and-suspenders: Monaco's automaticLayout ResizeObserver
 				// can lag a frame on first reveal of a previously-hidden
 				// container; force a sync layout against real dims.
@@ -117,10 +125,6 @@ export async function initApp(
 	const client = await sandbox.actions.boot(iframe, manifestOverride);
 	if (!client) return;
 
-	// Assign saveHandler before any further awaits — closes a window where
-	// a toggle click between boot resolving and saveHandler being set could
-	// run ensureEditorLoaded with a null saveHandler and leave Cmd-S
-	// unregistered.
 	saveHandler = async (path, content) => {
 		await writeFile(client, path, content);
 		const currentUrl = await client.getCurrentURL();

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,7 @@ export async function initApp(
 
 	function closeTab(path: string, mod: EditorMod): void {
 		const idx = openTabs.findIndex((t) => t.path === path);
+		if (idx === -1) return;
 		openTabs.splice(idx, 1);
 		if (activeTab === path) {
 			activeTab = openTabs[idx]?.path ?? openTabs[idx - 1]?.path ?? null;

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,28 +69,40 @@ export async function initApp(
 	let saveHandler: ((path: string, content: string) => Promise<void>) | null =
 		null;
 
-	let editorLoadPromise: Promise<EditorMod> | null = null;
-	function ensureEditorLoaded(): Promise<EditorMod> {
+	let editorLoadPromise: Promise<EditorMod | null> | null = null;
+	function ensureEditorLoaded(): Promise<EditorMod | null> {
 		if (!editorLoadPromise) {
 			editorLoadPromise = (async () => {
-				// editor.js side-effect-imports monaco-environment.js, so
-				// MonacoEnvironment is registered before monaco.editor.create().
-				const mod = await import('./editor.js');
-				mod.initEditor(monacoContainer);
-				// Always register the save command. The wrapper resolves
-				// `saveHandler` at Cmd-S press time, so initialising the
-				// editor before `saveHandler` is assigned (toggle clicked
-				// during the gap between `state.isReady` flipping and
-				// `boot()` resolving) is safe — Cmd-S no-ops until the
-				// handler lands instead of permanently losing the binding.
-				mod.addSaveCommand((path, content) => {
-					saveHandler?.(path, content);
-				});
-				// Belt-and-suspenders: Monaco's automaticLayout ResizeObserver
-				// can lag a frame on first reveal of a previously-hidden
-				// container; force a sync layout against real dims.
-				requestAnimationFrame(() => mod.getEditor()?.layout());
-				return mod;
+				try {
+					// editor.js side-effect-imports monaco-environment.js, so
+					// MonacoEnvironment is registered before monaco.editor.create().
+					const mod = await import('./editor.js');
+					mod.initEditor(monacoContainer);
+					// Always register the save command. The wrapper resolves
+					// `saveHandler` at Cmd-S press time, so initialising the
+					// editor before `saveHandler` is assigned (toggle clicked
+					// during the gap between `state.isReady` flipping and
+					// `boot()` resolving) is safe — Cmd-S no-ops until the
+					// handler lands instead of permanently losing the binding.
+					mod.addSaveCommand((path, content) => {
+						saveHandler?.(path, content);
+					});
+					// Belt-and-suspenders: Monaco's automaticLayout ResizeObserver
+					// can lag a frame on first reveal of a previously-hidden
+					// container; force a sync layout against real dims.
+					requestAnimationFrame(() => mod.getEditor()?.layout());
+					return mod;
+				} catch (err) {
+					// Stale chunk after a plugin update or a transient network
+					// blip will surface here; clear the cached promise so the
+					// user can retry by toggling again, fall back to closed,
+					// and surface the failure in the status bar.
+					console.error('[live-sandbox-editor] Editor load failed:', err);
+					editorLoadPromise = null;
+					sandbox.state.editorOpen = false;
+					sandbox.state.statusText = 'Failed to load editor.';
+					return null;
+				}
 			})();
 		}
 		return editorLoadPromise;
@@ -105,7 +117,11 @@ export async function initApp(
 			*onEditorOpenChange(): Generator<Promise<unknown>, void> {
 				if (sandbox.state.editorOpen) {
 					yield ensureEditorLoaded();
-					fileTreeBody.focus();
+					// Re-check: ensureEditorLoaded flips editorOpen back to
+					// false on failure, which schedules another tick of this
+					// callback (the close branch). Skip focus here so the
+					// fallback tick can manage focus instead.
+					if (sandbox.state.editorOpen) fileTreeBody.focus();
 				} else {
 					// Clear inline widths set by the drag handle: their
 					// `width:Npx` would otherwise pin the preview pane to its
@@ -143,6 +159,10 @@ export async function initApp(
 
 	initFileExplorer(fileTreeBody, client, wpContentPath, async (filePath) => {
 		const mod = await ensureEditorLoaded();
+		// File-tree clicks should be unreachable when the editor isn't loaded
+		// (the tree lives inside the hidden editor pane), but if a load failure
+		// raced an in-flight click, just bail.
+		if (!mod) return;
 		const existingTab = openTabs.find((t) => t.path === filePath);
 		const label = filePath.split('/').pop() ?? filePath;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,7 +86,10 @@ export async function initApp(
 					// `boot()` resolving) is safe — Cmd-S no-ops until the
 					// handler lands instead of permanently losing the binding.
 					mod.addSaveCommand((path, content) => {
-						saveHandler?.(path, content);
+						saveHandler?.(path, content)?.catch((err) => {
+							console.error('[live-sandbox-editor] Save failed:', err);
+							sandbox.state.statusText = 'Save failed.';
+						});
 					});
 					// Belt-and-suspenders: Monaco's automaticLayout ResizeObserver
 					// can lag a frame on first reveal of a previously-hidden

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,3 +1,7 @@
+// Side-effect import: registers self.MonacoEnvironment.getWorker before any
+// monaco.editor.create() runs. Keep above the monaco import so worker
+// bindings are in place when monaco's static graph initialises.
+import './monaco-environment.js';
 import * as monaco from 'monaco-editor';
 
 let editor: monaco.editor.IStandaloneCodeEditor | null = null;
@@ -33,6 +37,10 @@ export function showInEditor(path: string | null): void {
 	}
 	const model = models.get(path);
 	if (model) editor.setModel(model);
+}
+
+export function getEditor(): monaco.editor.IStandaloneCodeEditor | null {
+	return editor;
 }
 
 export function getCurrentPath(): string | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import './monaco-environment.js';
 import { initApp } from './app.js';
 import type { SyncManifest } from './playground.js';
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,7 @@ export interface SandboxState {
 	url: string;
 	statusText: string;
 	isReady: boolean;
+	editorOpen: boolean;
 	readonly notReady: boolean;
 }
 
@@ -16,6 +17,7 @@ interface SandboxStore {
 		setUrl(event: Event): void;
 		navigate(event: Event): Generator<Promise<unknown>, void>;
 		refresh(): Generator<Promise<unknown>, void>;
+		toggleEditor(): void;
 		boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
@@ -50,6 +52,9 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			if (!client) return;
 			const currentUrl = (yield client.getCurrentURL()) as string;
 			yield client.goTo(currentUrl);
+		},
+		toggleEditor(): void {
+			sandbox.state.editorOpen = !sandbox.state.editorOpen;
 		},
 		*boot(
 			iframe: HTMLIFrameElement,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -38,6 +38,16 @@ export default defineConfig({
 				// dynamic chunks and share `./monaco-[hash].js` with main.js.
 				codeSplitting: {
 					groups: [
+						// Vite's __vitePreload helper is a synthetic module shared
+						// between any chunk that performs dynamic imports. Without
+						// pinning it to its own chunk, rolldown hoists it into the
+						// largest consumer (here: monaco), which forces main.js to
+						// statically import the monaco chunk just to reach the
+						// helper — defeating the lazy-load goal.
+						{
+							name: 'preload-helper',
+							test: (id) => id.includes('preload-helper'),
+						},
 						{
 							name: 'monaco',
 							test: (id) =>


### PR DESCRIPTION
## Summary
- Move the URL toolbar above `.lse-main` so it spans the full content width; add a Dashicon toggle button that shows/hides the editor side (file tree + tabs + Monaco). The run view now opens on the preview, full width.
- Defer Monaco loading until the toggle is pressed: \`editor.ts\` is reached via a memoised dynamic \`import()\` in \`app.ts\` and side-effect-imports \`monaco-environment.ts\` so worker registration happens before \`monaco.editor.create()\`. \`main.ts\` no longer eagerly imports the environment module.
- Pin Vite's \`__vitePreload\` synthetic helper to its own chunk via \`codeSplitting.groups\`; otherwise rolldown hoists it into the monaco chunk and \`main.js\` statically imports the 4 MB monaco chunk just to reach the helper.
- Wire the toggle through the Interactivity API: \`data-wp-class--editor-open\` drives layout, \`data-wp-watch--editor\` calls the editor loader and manages focus. Default-closed CSS avoids a hydration flash. Inline pane widths set by the drag handle are cleared on close so the preview fills the row instead of being pinned to its dragged width.

## Test plan
- [x] \`npm run build\` clean; \`grep -E '(monaco|worker)' build/main.js\` produces no static reach into monaco's chunk (only the dynamic \`import('./editor-*.js')\` and the deps-map referencing \`monaco.css\`).
- [x] \`npx tsgo --noEmit\`, \`npx biome check .\`, \`composer lint:src\`, \`php -l\` on touched PHP files — all clean.
- [x] Initial paint: full-width toolbar; preview fills the row; no editor visible.
- [x] Network: \`monaco-*.js\` and \`*.worker.js\` are not requested before clicking the toggle (verified via \`PerformanceEntry\` timestamps — Monaco assets fetch only after the click).
- [x] Toggle open: editor pane appears; Monaco renders at full pane height; clicking a file opens a tab with PHP syntax highlighting; status bar updates.
- [x] Toggle closed: preview returns to full width; \`aria-pressed\` flips to \`false\`; focus returns to the toggle button.
- [x] Drag-then-toggle: closing clears inline pane widths so the preview fills the row; reopening returns to the default 40/60 split (drag preference is intentionally not preserved across toggles — preserving it left the preview pinned to its dragged width with empty space where the editor used to be).