### PR TITLE
Add select all/active/none controls to Setup lists

### DIFF
--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -352,3 +352,10 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 .lse-setup .lse-setup-group li {
 	margin: 0;
 }
+
+.lse-setup .lse-setup-actions {
+	display: flex;
+	gap: 12px;
+	margin: 0 0 8px;
+	font-size: 12px;
+}

--- a/live-sandbox-editor/templates/setup-view.php
+++ b/live-sandbox-editor/templates/setup-view.php
@@ -30,8 +30,19 @@ namespace Live_Sandbox_Editor;
 	</div>
 
 	<div data-wp-class--lse-hidden="state.loading || state.loadError">
-		<fieldset class="lse-setup-group">
+		<fieldset class="lse-setup-group" data-wp-context='{"group":"plugins"}'>
 			<legend><?php esc_html_e( 'Plugins', 'live-sandbox-editor' ); ?></legend>
+			<div class="lse-setup-actions">
+				<button type="button" class="button-link" data-wp-on--click="actions.selectAll">
+					<?php esc_html_e( 'Select all', 'live-sandbox-editor' ); ?>
+				</button>
+				<button type="button" class="button-link" data-wp-on--click="actions.selectActive">
+					<?php esc_html_e( 'Select active', 'live-sandbox-editor' ); ?>
+				</button>
+				<button type="button" class="button-link" data-wp-on--click="actions.deselectAll">
+					<?php esc_html_e( 'Deselect all', 'live-sandbox-editor' ); ?>
+				</button>
+			</div>
 			<ul>
 				<template data-wp-each--item="state.plugins">
 					<li>
@@ -44,8 +55,19 @@ namespace Live_Sandbox_Editor;
 			</ul>
 		</fieldset>
 
-		<fieldset class="lse-setup-group">
+		<fieldset class="lse-setup-group" data-wp-context='{"group":"themes"}'>
 			<legend><?php esc_html_e( 'Themes', 'live-sandbox-editor' ); ?></legend>
+			<div class="lse-setup-actions">
+				<button type="button" class="button-link" data-wp-on--click="actions.selectAll">
+					<?php esc_html_e( 'Select all', 'live-sandbox-editor' ); ?>
+				</button>
+				<button type="button" class="button-link" data-wp-on--click="actions.selectActive">
+					<?php esc_html_e( 'Select active', 'live-sandbox-editor' ); ?>
+				</button>
+				<button type="button" class="button-link" data-wp-on--click="actions.deselectAll">
+					<?php esc_html_e( 'Deselect all', 'live-sandbox-editor' ); ?>
+				</button>
+			</div>
 			<ul>
 				<template data-wp-each--item="state.themes">
 					<li>
@@ -58,8 +80,16 @@ namespace Live_Sandbox_Editor;
 			</ul>
 		</fieldset>
 
-		<fieldset class="lse-setup-group">
+		<fieldset class="lse-setup-group" data-wp-context='{"group":"tables"}'>
 			<legend><?php esc_html_e( 'Tables', 'live-sandbox-editor' ); ?></legend>
+			<div class="lse-setup-actions">
+				<button type="button" class="button-link" data-wp-on--click="actions.selectAll">
+					<?php esc_html_e( 'Select all', 'live-sandbox-editor' ); ?>
+				</button>
+				<button type="button" class="button-link" data-wp-on--click="actions.deselectAll">
+					<?php esc_html_e( 'Deselect all', 'live-sandbox-editor' ); ?>
+				</button>
+			</div>
 			<ul>
 				<template data-wp-each--item="state.tables">
 					<li>

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,7 +8,10 @@ interface Item {
 	id: string;
 	label: string;
 	selected: boolean;
+	active: boolean;
 }
+
+type ItemGroup = 'plugins' | 'themes' | 'tables';
 
 interface SetupState {
 	loading: boolean;
@@ -25,6 +28,9 @@ interface SetupStore {
 	actions: {
 		toggleItem(): void;
 		toggleUploads(): void;
+		selectAll(): void;
+		deselectAll(): void;
+		selectActive(): void;
 		retry(): void;
 		run(): void;
 	};
@@ -55,6 +61,24 @@ const setup = store<SetupStore>('live-sandbox-editor/setup', {
 		toggleUploads(): void {
 			setup.state.uploads = !setup.state.uploads;
 		},
+		selectAll(): void {
+			const ctx = getContext<{ group: ItemGroup }>();
+			for (const item of setup.state[ctx.group]) {
+				item.selected = true;
+			}
+		},
+		deselectAll(): void {
+			const ctx = getContext<{ group: ItemGroup }>();
+			for (const item of setup.state[ctx.group]) {
+				item.selected = false;
+			}
+		},
+		selectActive(): void {
+			const ctx = getContext<{ group: ItemGroup }>();
+			for (const item of setup.state[ctx.group]) {
+				item.selected = item.active;
+			}
+		},
 		retry(): void {
 			void loadDefaults();
 		},
@@ -81,7 +105,10 @@ function buildItems(
 ): Item[] {
 	const activeSet = new Set(active);
 	return Object.entries(labels ?? {})
-		.map(([id, label]) => ({ id, label, selected: activeSet.has(id) }))
+		.map(([id, label]) => {
+			const isActive = activeSet.has(id);
+			return { id, label, selected: isActive, active: isActive };
+		})
 		.sort((a, b) =>
 			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
 		);
@@ -105,6 +132,7 @@ async function loadDefaults(): Promise<void> {
 			id,
 			label: id,
 			selected: true,
+			active: true,
 		}));
 		setup.state.uploads = data.manifest.uploads;
 		setup.state.loading = false;


### PR DESCRIPTION
## Summary
- Plugins and Themes lists in the Setup view get **Select all**, **Select active**, **Deselect all** buttons.
- Tables list gets **Select all** / **Deselect all** (no active/inactive distinction in that data).
- `Item` now tracks `active` alongside `selected` so "Select active" restores the original WP-active set after edits.

Actions read the target group from Interactivity context (`data-wp-context='{"group":"plugins"}'`), so a single set of actions handles all three fieldsets.

Closes #38

## Test plan
- [ ] Open the Setup view; confirm each fieldset shows the new button row.
- [ ] In Plugins/Themes, click each of Select all / Select active / Deselect all and confirm the checkboxes update accordingly.
- [ ] In Tables, confirm Select all / Deselect all work; no Select active button is rendered.
- [ ] Confirm the Run button's enabled/disabled state still tracks selection correctly after using the bulk actions.