### PR TITLE
Add quick-links menu to the URL bar

### DIFF
--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -104,10 +104,11 @@ function enqueue_assets( string $hook_suffix ): void {
 	wp_interactivity_state(
 		SLUG . '/sandbox',
 		array(
-			'url'        => '',
-			'statusText' => 'Initializing…',
-			'isReady'    => false,
-			'editorOpen' => false,
+			'url'         => '',
+			'statusText'  => 'Initializing…',
+			'isReady'     => false,
+			'editorOpen'  => false,
+			'urlMenuOpen' => false,
 		)
 	);
 

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -282,28 +282,6 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	outline: none;
 }
 
-.lse-url-menu-toggle {
-	background: transparent;
-	color: #999;
-	border: none;
-	border-left: 1px solid #3c3c3c;
-	padding: 0 8px;
-	cursor: pointer;
-	font-size: 12px;
-	line-height: 1;
-	flex-shrink: 0;
-}
-
-.lse-url-menu-toggle:hover:not(:disabled) {
-	color: #fff;
-	background: #2a2d2e;
-}
-
-.lse-url-menu-toggle:disabled {
-	opacity: 0.5;
-	cursor: not-allowed;
-}
-
 .lse-url-menu {
 	position: absolute;
 	top: calc(100% + 4px);

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -255,21 +255,109 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	margin: 0;
 }
 
+.lse-url-form-group {
+	flex: 1;
+	min-width: 0;
+	position: relative;
+	display: flex;
+	align-items: stretch;
+	background: #1e1e1e;
+	border: 1px solid #3c3c3c;
+	border-radius: 3px;
+}
+
+.lse-url-form-group:focus-within {
+	border-color: #007acc;
+}
+
 .lse-url-input {
 	flex: 1;
 	min-width: 0;
-	background: #1e1e1e;
+	background: transparent;
 	color: #ccc;
-	border: 1px solid #3c3c3c;
-	border-radius: 3px;
+	border: none;
 	padding: 4px 8px;
 	font: inherit;
 	font-size: 12px;
 	outline: none;
 }
 
-.lse-url-input:focus {
-	border-color: #007acc;
+.lse-url-menu-toggle {
+	background: transparent;
+	color: #999;
+	border: none;
+	border-left: 1px solid #3c3c3c;
+	padding: 0 8px;
+	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
+	flex-shrink: 0;
+}
+
+.lse-url-menu-toggle:hover:not(:disabled) {
+	color: #fff;
+	background: #2a2d2e;
+}
+
+.lse-url-menu-toggle:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.lse-url-menu {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	right: 0;
+	background: #252526;
+	border: 1px solid #3c3c3c;
+	border-radius: 3px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	padding: 4px 0;
+	z-index: 50;
+	max-height: 320px;
+	overflow-y: auto;
+}
+
+.lse-url-menu-item {
+	display: flex;
+	align-items: baseline;
+	gap: 12px;
+	width: 100%;
+	background: transparent;
+	color: #ccc;
+	border: none;
+	padding: 6px 12px;
+	font: inherit;
+	font-size: 12px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.lse-url-menu-item:hover,
+.lse-url-menu-item:focus {
+	background: #094771;
+	color: #fff;
+	outline: none;
+}
+
+.lse-url-menu-label {
+	flex-shrink: 0;
+	font-weight: 600;
+}
+
+.lse-url-menu-path {
+	color: #888;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.lse-url-menu-item:hover .lse-url-menu-path,
+.lse-url-menu-item:focus .lse-url-menu-path {
+	color: #cde;
 }
 
 .lse-preview-iframe {

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -14,6 +14,33 @@ namespace Live_Sandbox_Editor;
 
 \defined( 'ABSPATH' ) || exit;
 
+$quick_links = array(
+	array(
+		'label' => __( 'Homepage', 'live-sandbox-editor' ),
+		'path'  => '/',
+	),
+	array(
+		'label' => __( 'Dashboard', 'live-sandbox-editor' ),
+		'path'  => '/wp-admin/',
+	),
+	array(
+		'label' => __( 'Site Editor', 'live-sandbox-editor' ),
+		'path'  => '/wp-admin/site-editor.php',
+	),
+	array(
+		'label' => __( 'New Post', 'live-sandbox-editor' ),
+		'path'  => '/wp-admin/post-new.php',
+	),
+	array(
+		'label' => __( 'Plugins', 'live-sandbox-editor' ),
+		'path'  => '/wp-admin/plugins.php',
+	),
+	array(
+		'label' => __( 'Themes', 'live-sandbox-editor' ),
+		'path'  => '/wp-admin/themes.php',
+	),
+);
+
 ?>
 <div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox">
 	<div class="lse-toolbar">
@@ -35,18 +62,53 @@ namespace Live_Sandbox_Editor;
 			aria-label="Refresh"
 		>↺</button>
 		<form class="lse-url-form" data-wp-on--submit="actions.navigate">
-			<input
-				type="text"
-				class="lse-url-input"
-				placeholder="/wp-admin/"
-				data-wp-bind--value="state.url"
-				data-wp-bind--disabled="state.notReady"
-				data-wp-on--input="actions.setUrl"
-				aria-label="URL to visit in the playground"
-				autocomplete="off"
-				spellcheck="false"
-				disabled
-			>
+			<div class="lse-url-form-group">
+				<input
+					type="text"
+					class="lse-url-input"
+					placeholder="/wp-admin/"
+					data-wp-bind--value="state.url"
+					data-wp-bind--disabled="state.notReady"
+					data-wp-on--input="actions.setUrl"
+					data-wp-on--keydown="actions.onUrlInputKeydown"
+					aria-label="URL to visit in the playground"
+					autocomplete="off"
+					spellcheck="false"
+					disabled
+				>
+				<button
+					type="button"
+					class="lse-url-menu-toggle"
+					data-wp-on--click="actions.toggleUrlMenu"
+					data-wp-bind--disabled="state.notReady"
+					data-wp-bind--aria-expanded="state.urlMenuOpen"
+					aria-haspopup="menu"
+					aria-controls="lse-url-menu"
+					aria-label="Quick links"
+					disabled
+				>▾</button>
+				<div
+					id="lse-url-menu"
+					class="lse-url-menu"
+					role="menu"
+					data-wp-class--open="state.urlMenuOpen"
+					hidden
+					data-wp-bind--hidden="!state.urlMenuOpen"
+				>
+					<?php foreach ( $quick_links as $link ) : ?>
+						<button
+							type="button"
+							role="menuitem"
+							class="lse-url-menu-item"
+							data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'path' => $link['path'] ) ) ); ?>"
+							data-wp-on--click="actions.quickNavigate"
+						>
+							<span class="lse-url-menu-label"><?php echo esc_html( $link['label'] ); ?></span>
+							<span class="lse-url-menu-path"><?php echo esc_html( $link['path'] ); ?></span>
+						</button>
+					<?php endforeach; ?>
+				</div>
+			</div>
 		</form>
 	</div>
 	<div

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -84,7 +84,6 @@ $quick_links = array(
 					id="lse-url-menu"
 					class="lse-url-menu"
 					role="menu"
-					data-wp-class--open="state.urlMenuOpen"
 					hidden
 					data-wp-bind--hidden="!state.urlMenuOpen"
 				>

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -69,24 +69,16 @@ $quick_links = array(
 					placeholder="/wp-admin/"
 					data-wp-bind--value="state.url"
 					data-wp-bind--disabled="state.notReady"
+					data-wp-bind--aria-expanded="state.urlMenuOpen"
 					data-wp-on--input="actions.setUrl"
-					data-wp-on--keydown="actions.onUrlInputKeydown"
+					data-wp-on--focus="actions.openUrlMenu"
 					aria-label="URL to visit in the playground"
+					aria-haspopup="menu"
+					aria-controls="lse-url-menu"
 					autocomplete="off"
 					spellcheck="false"
 					disabled
 				>
-				<button
-					type="button"
-					class="lse-url-menu-toggle"
-					data-wp-on--click="actions.toggleUrlMenu"
-					data-wp-bind--disabled="state.notReady"
-					data-wp-bind--aria-expanded="state.urlMenuOpen"
-					aria-haspopup="menu"
-					aria-controls="lse-url-menu"
-					aria-label="Quick links"
-					disabled
-				>▾</button>
 				<div
 					id="lse-url-menu"
 					class="lse-url-menu"
@@ -100,6 +92,7 @@ $quick_links = array(
 							type="button"
 							role="menuitem"
 							class="lse-url-menu-item"
+							tabindex="-1"
 							data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'path' => $link['path'] ) ) ); ?>"
 							data-wp-on--click="actions.quickNavigate"
 						>

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -92,7 +92,6 @@ $quick_links = array(
 							type="button"
 							role="menuitem"
 							class="lse-url-menu-item"
-							tabindex="-1"
 							data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'path' => $link['path'] ) ) ); ?>"
 							data-wp-on--click="actions.quickNavigate"
 						>

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -72,6 +72,7 @@ $quick_links = array(
 					data-wp-bind--aria-expanded="state.urlMenuOpen"
 					data-wp-on--input="actions.setUrl"
 					data-wp-on--focus="actions.openUrlMenu"
+					data-wp-on--click="actions.openUrlMenu"
 					aria-label="URL to visit in the playground"
 					aria-haspopup="menu"
 					aria-controls="lse-url-menu"

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,9 +19,12 @@ export async function initApp(
 	const previewPane = mustQuery(root, '.lse-preview-pane');
 	const iframe = mustQuery(root, '#lse-preview-iframe') as HTMLIFrameElement;
 	const urlFormGroup = mustQuery(root, '.lse-url-form-group');
+	const urlInput = mustQuery(root, '.lse-url-input') as HTMLInputElement;
+	const urlMenu = mustQuery(root, '#lse-url-menu');
 
 	initDragHandle(dragHandle, editorPane, previewPane);
 	initUrlMenuDismiss(urlFormGroup, iframe);
+	initUrlMenuKeyboard(urlInput, urlMenu);
 
 	const openTabs: OpenFile[] = [];
 	let activeTab: string | null = null;
@@ -239,6 +242,62 @@ function initUrlMenuDismiss(
 	// input doesn't currently hold focus.
 	iframe.addEventListener('focus', () => {
 		sandbox.state.urlMenuOpen = false;
+	});
+}
+
+function initUrlMenuKeyboard(input: HTMLInputElement, menu: HTMLElement): void {
+	const items = (): HTMLButtonElement[] =>
+		Array.from(menu.querySelectorAll<HTMLButtonElement>('.lse-url-menu-item'));
+
+	input.addEventListener('keydown', (e) => {
+		if (e.key !== 'ArrowDown') return;
+		e.preventDefault();
+		const wasOpen = sandbox.state.urlMenuOpen;
+		sandbox.state.urlMenuOpen = true;
+		// `hidden` removal is applied async by the Interactivity API's signal
+		// flush (microtask). A hidden element can't receive focus, so wait
+		// one tick when opening from a closed state.
+		if (wasOpen) {
+			items()[0]?.focus();
+		} else {
+			queueMicrotask(() => items()[0]?.focus());
+		}
+	});
+
+	menu.addEventListener('keydown', (e) => {
+		const target = e.target;
+		if (
+			!(target instanceof HTMLElement) ||
+			!target.classList.contains('lse-url-menu-item')
+		) {
+			return;
+		}
+		const list = items();
+		const idx = list.indexOf(target as HTMLButtonElement);
+		switch (e.key) {
+			case 'ArrowDown':
+				e.preventDefault();
+				list[(idx + 1) % list.length]?.focus();
+				break;
+			case 'ArrowUp':
+				e.preventDefault();
+				if (idx === 0) input.focus();
+				else list[idx - 1]?.focus();
+				break;
+			case 'Home':
+				e.preventDefault();
+				list[0]?.focus();
+				break;
+			case 'End':
+				e.preventDefault();
+				list[list.length - 1]?.focus();
+				break;
+			case 'Escape':
+				// Document-level Escape handler closes the menu; refocus the
+				// input here so the user can keep typing without re-clicking.
+				input.focus();
+				break;
+		}
 	});
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,8 +18,10 @@ export async function initApp(
 	const editorPane = mustQuery(root, '.lse-editor-pane');
 	const previewPane = mustQuery(root, '.lse-preview-pane');
 	const iframe = mustQuery(root, '#lse-preview-iframe') as HTMLIFrameElement;
+	const urlFormGroup = mustQuery(root, '.lse-url-form-group');
 
 	initDragHandle(dragHandle, editorPane, previewPane);
+	initUrlMenuDismiss(urlFormGroup);
 
 	const openTabs: OpenFile[] = [];
 	let activeTab: string | null = null;
@@ -193,6 +195,23 @@ function mustQuery(root: HTMLElement, selector: string): HTMLElement {
 		throw new Error(`[live-sandbox-editor] Missing element ${selector}`);
 	}
 	return found;
+}
+
+function initUrlMenuDismiss(urlFormGroup: HTMLElement): void {
+	// The Interactivity API doesn't expose a generic "click outside" hook,
+	// so close the menu here when a pointerdown lands outside the URL form
+	// group (input + chevron + popover) or when Escape is pressed.
+	document.addEventListener('pointerdown', (e) => {
+		if (!sandbox.state.urlMenuOpen) return;
+		const target = e.target;
+		if (target instanceof Node && urlFormGroup.contains(target)) return;
+		sandbox.state.urlMenuOpen = false;
+	});
+	document.addEventListener('keydown', (e) => {
+		if (e.key === 'Escape' && sandbox.state.urlMenuOpen) {
+			sandbox.state.urlMenuOpen = false;
+		}
+	});
 }
 
 function initDragHandle(

--- a/src/app.ts
+++ b/src/app.ts
@@ -204,11 +204,12 @@ function initUrlMenuDismiss(
 	urlFormGroup: HTMLElement,
 	iframe: HTMLIFrameElement,
 ): void {
-	// Keep the URL input focused when a menu item is clicked. Without this,
-	// mousedown on the button steals focus and fires `focusout` on the
-	// input (closing the menu before `click` arrives). preventDefault on
-	// mousedown blocks the focus shift but leaves the click intact.
-	urlFormGroup.addEventListener('mousedown', (e) => {
+	// Keep the URL input focused when a menu item is activated. Without this,
+	// pressing on the button steals focus and fires `focusout` on the input
+	// (closing the menu before `click` arrives). preventDefault on
+	// `pointerdown` blocks the focus shift but leaves the click intact, and
+	// covers mouse, touch, and pen consistently.
+	urlFormGroup.addEventListener('pointerdown', (e) => {
 		const target = e.target;
 		if (target instanceof Element && target.closest('.lse-url-menu-item')) {
 			e.preventDefault();

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,7 @@ export async function initApp(
 	const urlFormGroup = mustQuery(root, '.lse-url-form-group');
 
 	initDragHandle(dragHandle, editorPane, previewPane);
-	initUrlMenuDismiss(urlFormGroup);
+	initUrlMenuDismiss(urlFormGroup, iframe);
 
 	const openTabs: OpenFile[] = [];
 	let activeTab: string | null = null;
@@ -197,10 +197,32 @@ function mustQuery(root: HTMLElement, selector: string): HTMLElement {
 	return found;
 }
 
-function initUrlMenuDismiss(urlFormGroup: HTMLElement): void {
-	// The Interactivity API doesn't expose a generic "click outside" hook,
-	// so close the menu here when a pointerdown lands outside the URL form
-	// group (input + chevron + popover) or when Escape is pressed.
+function initUrlMenuDismiss(
+	urlFormGroup: HTMLElement,
+	iframe: HTMLIFrameElement,
+): void {
+	// Keep the URL input focused when a menu item is clicked. Without this,
+	// mousedown on the button steals focus and fires `focusout` on the
+	// input (closing the menu before `click` arrives). preventDefault on
+	// mousedown blocks the focus shift but leaves the click intact.
+	urlFormGroup.addEventListener('mousedown', (e) => {
+		const target = e.target;
+		if (target instanceof Element && target.closest('.lse-url-menu-item')) {
+			e.preventDefault();
+		}
+	});
+	// Close on focus moving outside the form group. relatedTarget is null
+	// when focus moves into a cross-origin iframe (the preview), so that
+	// case is covered too.
+	urlFormGroup.addEventListener('focusout', (e) => {
+		if (!sandbox.state.urlMenuOpen) return;
+		const next = e.relatedTarget;
+		if (next instanceof Node && urlFormGroup.contains(next)) return;
+		sandbox.state.urlMenuOpen = false;
+	});
+	// Belt-and-suspenders: focusout already covers most outside-click and
+	// iframe-focus paths, but a click on a non-focusable element outside the
+	// form group leaves the input focused — this catches that.
 	document.addEventListener('pointerdown', (e) => {
 		if (!sandbox.state.urlMenuOpen) return;
 		const target = e.target;
@@ -211,6 +233,12 @@ function initUrlMenuDismiss(urlFormGroup: HTMLElement): void {
 		if (e.key === 'Escape' && sandbox.state.urlMenuOpen) {
 			sandbox.state.urlMenuOpen = false;
 		}
+	});
+	// Pointer events inside the cross-origin preview iframe don't bubble to
+	// the parent document, so this catches clicks in the preview when the
+	// input doesn't currently hold focus.
+	iframe.addEventListener('focus', () => {
+		sandbox.state.urlMenuOpen = false;
 	});
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { store } from '@wordpress/interactivity';
+import { getContext, store } from '@wordpress/interactivity';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { initPlayground, type SyncManifest } from './playground.js';
 import { getAppData } from './types.js';
@@ -8,6 +8,7 @@ export interface SandboxState {
 	statusText: string;
 	isReady: boolean;
 	editorOpen: boolean;
+	urlMenuOpen: boolean;
 	readonly notReady: boolean;
 }
 
@@ -18,6 +19,10 @@ interface SandboxStore {
 		navigate(event: Event): Generator<Promise<unknown>, void>;
 		refresh(): Generator<Promise<unknown>, void>;
 		toggleEditor(): void;
+		toggleUrlMenu(): void;
+		closeUrlMenu(): void;
+		quickNavigate(): Generator<Promise<unknown>, void>;
+		onUrlInputKeydown(event: KeyboardEvent): void;
 		boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
@@ -45,6 +50,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		},
 		*navigate(event: Event): Generator<Promise<unknown>, void> {
 			event.preventDefault();
+			sandbox.state.urlMenuOpen = false;
 			if (!client) return;
 			yield client.goTo(sandbox.state.url);
 		},
@@ -55,6 +61,29 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		},
 		toggleEditor(): void {
 			sandbox.state.editorOpen = !sandbox.state.editorOpen;
+		},
+		toggleUrlMenu(): void {
+			sandbox.state.urlMenuOpen = !sandbox.state.urlMenuOpen;
+		},
+		closeUrlMenu(): void {
+			sandbox.state.urlMenuOpen = false;
+		},
+		*quickNavigate(): Generator<Promise<unknown>, void> {
+			const { path } = getContext<{ path: string }>();
+			sandbox.state.urlMenuOpen = false;
+			sandbox.state.url = path;
+			if (!client) return;
+			yield client.goTo(path);
+		},
+		onUrlInputKeydown(event: KeyboardEvent): void {
+			if (event.key === 'Escape' && sandbox.state.urlMenuOpen) {
+				sandbox.state.urlMenuOpen = false;
+				return;
+			}
+			if (event.key === 'ArrowDown' && !sandbox.state.urlMenuOpen) {
+				event.preventDefault();
+				sandbox.state.urlMenuOpen = true;
+			}
 		},
 		*boot(
 			iframe: HTMLIFrameElement,

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,10 +19,8 @@ interface SandboxStore {
 		navigate(event: Event): Generator<Promise<unknown>, void>;
 		refresh(): Generator<Promise<unknown>, void>;
 		toggleEditor(): void;
-		toggleUrlMenu(): void;
-		closeUrlMenu(): void;
+		openUrlMenu(): void;
 		quickNavigate(): Generator<Promise<unknown>, void>;
-		onUrlInputKeydown(event: KeyboardEvent): void;
 		boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
@@ -62,11 +60,8 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		toggleEditor(): void {
 			sandbox.state.editorOpen = !sandbox.state.editorOpen;
 		},
-		toggleUrlMenu(): void {
-			sandbox.state.urlMenuOpen = !sandbox.state.urlMenuOpen;
-		},
-		closeUrlMenu(): void {
-			sandbox.state.urlMenuOpen = false;
+		openUrlMenu(): void {
+			sandbox.state.urlMenuOpen = true;
 		},
 		*quickNavigate(): Generator<Promise<unknown>, void> {
 			const { path } = getContext<{ path: string }>();
@@ -74,16 +69,6 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			sandbox.state.url = path;
 			if (!client) return;
 			yield client.goTo(path);
-		},
-		onUrlInputKeydown(event: KeyboardEvent): void {
-			if (event.key === 'Escape' && sandbox.state.urlMenuOpen) {
-				sandbox.state.urlMenuOpen = false;
-				return;
-			}
-			if (event.key === 'ArrowDown' && !sandbox.state.urlMenuOpen) {
-				event.preventDefault();
-				sandbox.state.urlMenuOpen = true;
-			}
 		},
 		*boot(
 			iframe: HTMLIFrameElement,

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,11 @@ interface SandboxStore {
 
 let client: PlaygroundClient | null = null;
 
+// Set by quickNavigate when it programmatically refocuses the URL input
+// after a keyboard activation; consumed by openUrlMenu so the resulting
+// focus event doesn't immediately reopen the menu we just closed.
+let suppressNextOpen = false;
+
 // Primitive initial values are authoritative in PHP via
 // `wp_interactivity_state` (see live-sandbox-editor/live-sandbox-editor.php).
 // Only the derived `notReady` getter is declared here; the rest of the shape
@@ -61,12 +66,26 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			sandbox.state.editorOpen = !sandbox.state.editorOpen;
 		},
 		openUrlMenu(): void {
+			if (suppressNextOpen) {
+				suppressNextOpen = false;
+				return;
+			}
 			sandbox.state.urlMenuOpen = true;
 		},
 		*quickNavigate(): Generator<Promise<unknown>, void> {
 			const { path } = getContext<{ path: string }>();
 			sandbox.state.urlMenuOpen = false;
 			sandbox.state.url = path;
+			// Keyboard activation (Enter/Space) leaves focus on the menu
+			// button that the bound `hidden` then makes invisible — focus
+			// would fall back to body. Move it to the URL input so the user
+			// can keep typing. The suppress flag stops the focus event from
+			// reopening the menu.
+			const input = document.querySelector<HTMLInputElement>('.lse-url-input');
+			if (input && document.activeElement !== input) {
+				suppressNextOpen = true;
+				input.focus();
+			}
 			if (!client) return;
 			yield client.goTo(path);
 		},


### PR DESCRIPTION
## Summary

- Focusing the URL input opens a popover with quick-nav links (Homepage, Dashboard, Site Editor, New Post, Plugins, Themes), mirroring playground.wordpress.net's address bar.
- Keyboard-operable: ArrowDown opens and focuses the first item, ArrowUp/Down navigate, Home/End jump, Enter activates, Tab past the last item closes; Escape returns focus to the input.
- Dismisses on outside click, on focus moving into the cross-origin preview iframe, and on form submit.

Closes #33

## Test plan

- [x] Click the URL input → menu appears
- [x] Click a menu item → iframe navigates to that path, menu closes
- [x] Keyboard: ArrowDown → first item focused; ArrowDown/Up navigate; Enter activates; Escape returns focus to input
- [x] Click outside the form group → menu closes
- [x] Click into the preview iframe with menu open → menu closes
- [x] Submit URL via Enter on input → menu closes, navigation runs
- [x] No hydration warnings; type-check, biome, and PHP lint clean