### PR TITLE
Add Monaco theme picker (Auto/Light/Dark) and theme the editor chrome

### DIFF
--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -474,3 +474,138 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	margin: 0 0 8px;
 	font-size: 12px;
 }
+
+/* Light theme overrides — kept selector-based against the default dark
+   palette above. Surfaces use the wp-admin native palette (#f0f0f1 body,
+   #ffffff cards, #dcdcde borders, #1d2327 / #50575e text) so the editor
+   chrome blends with wp-admin. Status bar (#007acc) reads in both
+   themes; active highlights flip from VS-Code navy (#094771) to WP-admin
+   primary blue (#2271b1). */
+#live-sandbox-editor-root.lse-theme-light {
+	background: #ffffff;
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-file-tree {
+	background: #f0f0f1;
+	border-right-color: #dcdcde;
+}
+
+.lse-theme-light .lse-file-tree-header {
+	color: #50575e;
+	border-bottom-color: #dcdcde;
+}
+
+.lse-theme-light .lse-tree-item:hover {
+	background: #e7e7e7;
+}
+
+.lse-theme-light .lse-editor-toolbar {
+	background: #f0f0f1;
+	border-bottom-color: #dcdcde;
+}
+
+.lse-theme-light .lse-theme-toggle {
+	background: #ffffff;
+	border-color: #dcdcde;
+}
+
+.lse-theme-light .lse-theme-toggle-option {
+	color: #50575e;
+}
+
+.lse-theme-light .lse-theme-toggle-option:hover {
+	color: #1d2327;
+}
+
+/* `color: #fff` is repeated on each active rule because the base
+   `.lse-theme-light .lse-toolbar-btn` / `.lse-theme-toggle-option` /
+   `.lse-url-menu-item` overrides set a dark text color at the same
+   specificity and come later in the source order — without an explicit
+   white here, the active blue surfaces would render dark text on blue. */
+.lse-theme-light .lse-theme-toggle-option.is-active {
+	background: #2271b1;
+	color: #fff;
+}
+
+.lse-theme-light .lse-tree-item.selected {
+	background: #2271b1;
+}
+
+.lse-theme-light .lse-toolbar-btn[aria-pressed="true"] {
+	background: #2271b1;
+	border-color: #2271b1;
+	color: #fff;
+}
+
+.lse-theme-light .lse-url-menu-item:hover,
+.lse-theme-light .lse-url-menu-item:focus {
+	background: #2271b1;
+	color: #fff;
+}
+
+.lse-theme-light .lse-tabs {
+	background: #f0f0f1;
+	border-bottom-color: #dcdcde;
+}
+
+.lse-theme-light .lse-tab {
+	color: #50575e;
+	border-right-color: #dcdcde;
+}
+
+.lse-theme-light .lse-tab.active {
+	background: #ffffff;
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-drag-handle {
+	background: #dcdcde;
+}
+
+.lse-theme-light .lse-toolbar {
+	background: #f0f0f1;
+	border-bottom-color: #dcdcde;
+}
+
+.lse-theme-light .lse-toolbar-btn {
+	color: #1d2327;
+	border-color: #dcdcde;
+}
+
+.lse-theme-light .lse-toolbar-btn:hover {
+	background: #e7e7e7;
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-toolbar-btn:disabled:hover {
+	background: transparent;
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-url-form-group {
+	background: #ffffff;
+	border-color: #dcdcde;
+}
+
+.lse-theme-light .lse-url-input {
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-url-menu {
+	background: #ffffff;
+	border-color: #dcdcde;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.lse-theme-light .lse-url-menu-item {
+	color: #1d2327;
+}
+
+.lse-theme-light .lse-url-menu-path {
+	color: #50575e;
+}
+
+.lse-theme-light .lse-loading {
+	background: rgba(255, 255, 255, 0.92);
+}

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -115,6 +115,54 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	overflow: hidden;
 }
 
+.lse-editor-toolbar {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	background: #252526;
+	border-bottom: 1px solid #3c3c3c;
+	padding: 4px 8px;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.lse-theme-toggle {
+	display: inline-flex;
+	background: #1e1e1e;
+	border: 1px solid #3c3c3c;
+	border-radius: 4px;
+	padding: 2px;
+	gap: 2px;
+}
+
+.lse-theme-toggle-option {
+	background: transparent;
+	color: #bbb;
+	border: none;
+	border-radius: 3px;
+	padding: 3px 10px;
+	font: inherit;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	cursor: pointer;
+	min-height: 22px;
+}
+
+.lse-theme-toggle-option:hover {
+	color: #fff;
+}
+
+.lse-theme-toggle-option:focus-visible {
+	outline: 2px solid #007acc;
+	outline-offset: -1px;
+}
+
+.lse-theme-toggle-option.is-active {
+	background: #094771;
+	color: #fff;
+}
+
 .lse-tabs {
 	display: flex;
 	background: #252526;
@@ -156,6 +204,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-monaco-container {
 	flex: 1;
+	min-height: 0;
 }
 
 /* Drag handle (hidden by default; shown when editor is open) */

--- a/live-sandbox-editor/style.css
+++ b/live-sandbox-editor/style.css
@@ -36,8 +36,9 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	background: #1e1e1e;
-	color: #ccc;
+	background: light-dark(#ffffff, #1e1e1e);
+	color: light-dark(#1d2327, #ccc);
+	color-scheme: light dark;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 	font-size: 13px;
 }
@@ -61,8 +62,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 .lse-file-tree {
 	width: 220px;
 	flex-shrink: 0;
-	background: #252526;
-	border-right: 1px solid #3c3c3c;
+	background: light-dark(#f0f0f1, #252526);
+	border-right: 1px solid light-dark(#dcdcde, #3c3c3c);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -74,9 +75,9 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	font-weight: 700;
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
-	color: #bbb;
+	color: light-dark(#50575e, #bbb);
 	flex-shrink: 0;
-	border-bottom: 1px solid #3c3c3c;
+	border-bottom: 1px solid light-dark(#dcdcde, #3c3c3c);
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -99,10 +100,10 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-tree-item:hover {
-	background: #2a2d2e;
+	background: light-dark(#e7e7e7, #2a2d2e);
 }
 .lse-tree-item.selected {
-	background: #094771;
+	background: light-dark(#2271b1, #094771);
 	color: #fff;
 }
 
@@ -119,8 +120,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
-	background: #252526;
-	border-bottom: 1px solid #3c3c3c;
+	background: light-dark(#f0f0f1, #252526);
+	border-bottom: 1px solid light-dark(#dcdcde, #3c3c3c);
 	padding: 4px 8px;
 	gap: 6px;
 	flex-shrink: 0;
@@ -128,8 +129,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-theme-toggle {
 	display: inline-flex;
-	background: #1e1e1e;
-	border: 1px solid #3c3c3c;
+	background: light-dark(#ffffff, #1e1e1e);
+	border: 1px solid light-dark(#dcdcde, #3c3c3c);
 	border-radius: 4px;
 	padding: 2px;
 	gap: 2px;
@@ -137,7 +138,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-theme-toggle-option {
 	background: transparent;
-	color: #bbb;
+	color: light-dark(#50575e, #bbb);
 	border: none;
 	border-radius: 3px;
 	padding: 3px 10px;
@@ -150,7 +151,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-theme-toggle-option:hover {
-	color: #fff;
+	color: light-dark(#1d2327, #fff);
 }
 
 .lse-theme-toggle-option:focus-visible {
@@ -159,14 +160,14 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-theme-toggle-option.is-active {
-	background: #094771;
+	background: light-dark(#2271b1, #094771);
 	color: #fff;
 }
 
 .lse-tabs {
 	display: flex;
-	background: #252526;
-	border-bottom: 1px solid #3c3c3c;
+	background: light-dark(#f0f0f1, #252526);
+	border-bottom: 1px solid light-dark(#dcdcde, #3c3c3c);
 	overflow-x: auto;
 	flex-shrink: 0;
 	min-height: 35px;
@@ -175,8 +176,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 .lse-tab {
 	padding: 6px 20px 6px 12px;
 	cursor: pointer;
-	color: #969696;
-	border-right: 1px solid #3c3c3c;
+	color: light-dark(#50575e, #969696);
+	border-right: 1px solid light-dark(#dcdcde, #3c3c3c);
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -186,8 +187,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-tab.active {
-	background: #1e1e1e;
-	color: #fff;
+	background: light-dark(#ffffff, #1e1e1e);
+	color: light-dark(#1d2327, #fff);
 	border-top: 2px solid #007acc;
 }
 
@@ -210,7 +211,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 /* Drag handle (hidden by default; shown when editor is open) */
 .lse-drag-handle {
 	width: 4px;
-	background: #3c3c3c;
+	background: light-dark(#dcdcde, #3c3c3c);
 	cursor: col-resize;
 	flex-shrink: 0;
 	display: none;
@@ -246,8 +247,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 /* Top toolbar (full width, lifted from the preview pane). */
 .lse-toolbar {
 	min-height: 36px;
-	background: #2d2d2d;
-	border-bottom: 1px solid #3c3c3c;
+	background: light-dark(#f0f0f1, #2d2d2d);
+	border-bottom: 1px solid light-dark(#dcdcde, #3c3c3c);
 	display: flex;
 	align-items: center;
 	padding: 4px 8px;
@@ -258,8 +259,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-toolbar-btn {
 	background: transparent;
-	color: #ccc;
-	border: 1px solid #3c3c3c;
+	color: light-dark(#1d2327, #ccc);
+	border: 1px solid light-dark(#dcdcde, #3c3c3c);
 	border-radius: 3px;
 	padding: 3px 8px;
 	cursor: pointer;
@@ -276,14 +277,14 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-toolbar-btn[aria-pressed="true"] {
-	background: #094771;
+	background: light-dark(#2271b1, #094771);
 	color: #fff;
-	border-color: #094771;
+	border-color: light-dark(#2271b1, #094771);
 }
 
 .lse-toolbar-btn:hover {
-	background: #2a2d2e;
-	color: #fff;
+	background: light-dark(#e7e7e7, #2a2d2e);
+	color: light-dark(#1d2327, #fff);
 }
 
 .lse-toolbar-btn:disabled,
@@ -294,7 +295,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-toolbar-btn:disabled:hover {
 	background: transparent;
-	color: #ccc;
+	color: light-dark(#1d2327, #ccc);
 }
 
 .lse-url-form {
@@ -310,8 +311,8 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	position: relative;
 	display: flex;
 	align-items: stretch;
-	background: #1e1e1e;
-	border: 1px solid #3c3c3c;
+	background: light-dark(#ffffff, #1e1e1e);
+	border: 1px solid light-dark(#dcdcde, #3c3c3c);
 	border-radius: 3px;
 }
 
@@ -323,7 +324,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	flex: 1;
 	min-width: 0;
 	background: transparent;
-	color: #ccc;
+	color: light-dark(#1d2327, #ccc);
 	border: none;
 	padding: 4px 8px;
 	font: inherit;
@@ -336,10 +337,10 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	top: calc(100% + 4px);
 	left: 0;
 	right: 0;
-	background: #252526;
-	border: 1px solid #3c3c3c;
+	background: light-dark(#ffffff, #252526);
+	border: 1px solid light-dark(#dcdcde, #3c3c3c);
 	border-radius: 3px;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 4px 12px light-dark(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.4));
 	padding: 4px 0;
 	z-index: 50;
 	max-height: 320px;
@@ -352,7 +353,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	gap: 12px;
 	width: 100%;
 	background: transparent;
-	color: #ccc;
+	color: light-dark(#1d2327, #ccc);
 	border: none;
 	padding: 6px 12px;
 	font: inherit;
@@ -363,7 +364,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-url-menu-item:hover,
 .lse-url-menu-item:focus {
-	background: #094771;
+	background: light-dark(#2271b1, #094771);
 	color: #fff;
 	outline: none;
 }
@@ -374,7 +375,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 }
 
 .lse-url-menu-path {
-	color: #888;
+	color: light-dark(#50575e, #888);
 	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -384,7 +385,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 
 .lse-url-menu-item:hover .lse-url-menu-path,
 .lse-url-menu-item:focus .lse-url-menu-path {
-	color: #cde;
+	color: light-dark(#fff, #cde);
 }
 
 .lse-preview-iframe {
@@ -410,7 +411,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 .lse-loading {
 	position: fixed;
 	inset: 0;
-	background: rgba(30, 30, 30, 0.92);
+	background: light-dark(rgba(255, 255, 255, 0.92), rgba(30, 30, 30, 0.92));
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -427,7 +428,7 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 .lse-spinner {
 	width: 24px;
 	height: 24px;
-	border: 3px solid #555;
+	border: 3px solid light-dark(#d0d0d0, #555);
 	border-top-color: #007acc;
 	border-radius: 50%;
 	animation: lse-spin 0.8s linear infinite;
@@ -473,139 +474,4 @@ body.live-sandbox-editor_page_live-sandbox-editor #wpbody-content {
 	gap: 12px;
 	margin: 0 0 8px;
 	font-size: 12px;
-}
-
-/* Light theme overrides — kept selector-based against the default dark
-   palette above. Surfaces use the wp-admin native palette (#f0f0f1 body,
-   #ffffff cards, #dcdcde borders, #1d2327 / #50575e text) so the editor
-   chrome blends with wp-admin. Status bar (#007acc) reads in both
-   themes; active highlights flip from VS-Code navy (#094771) to WP-admin
-   primary blue (#2271b1). */
-#live-sandbox-editor-root.lse-theme-light {
-	background: #ffffff;
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-file-tree {
-	background: #f0f0f1;
-	border-right-color: #dcdcde;
-}
-
-.lse-theme-light .lse-file-tree-header {
-	color: #50575e;
-	border-bottom-color: #dcdcde;
-}
-
-.lse-theme-light .lse-tree-item:hover {
-	background: #e7e7e7;
-}
-
-.lse-theme-light .lse-editor-toolbar {
-	background: #f0f0f1;
-	border-bottom-color: #dcdcde;
-}
-
-.lse-theme-light .lse-theme-toggle {
-	background: #ffffff;
-	border-color: #dcdcde;
-}
-
-.lse-theme-light .lse-theme-toggle-option {
-	color: #50575e;
-}
-
-.lse-theme-light .lse-theme-toggle-option:hover {
-	color: #1d2327;
-}
-
-/* `color: #fff` is repeated on each active rule because the base
-   `.lse-theme-light .lse-toolbar-btn` / `.lse-theme-toggle-option` /
-   `.lse-url-menu-item` overrides set a dark text color at the same
-   specificity and come later in the source order — without an explicit
-   white here, the active blue surfaces would render dark text on blue. */
-.lse-theme-light .lse-theme-toggle-option.is-active {
-	background: #2271b1;
-	color: #fff;
-}
-
-.lse-theme-light .lse-tree-item.selected {
-	background: #2271b1;
-}
-
-.lse-theme-light .lse-toolbar-btn[aria-pressed="true"] {
-	background: #2271b1;
-	border-color: #2271b1;
-	color: #fff;
-}
-
-.lse-theme-light .lse-url-menu-item:hover,
-.lse-theme-light .lse-url-menu-item:focus {
-	background: #2271b1;
-	color: #fff;
-}
-
-.lse-theme-light .lse-tabs {
-	background: #f0f0f1;
-	border-bottom-color: #dcdcde;
-}
-
-.lse-theme-light .lse-tab {
-	color: #50575e;
-	border-right-color: #dcdcde;
-}
-
-.lse-theme-light .lse-tab.active {
-	background: #ffffff;
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-drag-handle {
-	background: #dcdcde;
-}
-
-.lse-theme-light .lse-toolbar {
-	background: #f0f0f1;
-	border-bottom-color: #dcdcde;
-}
-
-.lse-theme-light .lse-toolbar-btn {
-	color: #1d2327;
-	border-color: #dcdcde;
-}
-
-.lse-theme-light .lse-toolbar-btn:hover {
-	background: #e7e7e7;
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-toolbar-btn:disabled:hover {
-	background: transparent;
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-url-form-group {
-	background: #ffffff;
-	border-color: #dcdcde;
-}
-
-.lse-theme-light .lse-url-input {
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-url-menu {
-	background: #ffffff;
-	border-color: #dcdcde;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-}
-
-.lse-theme-light .lse-url-menu-item {
-	color: #1d2327;
-}
-
-.lse-theme-light .lse-url-menu-path {
-	color: #50575e;
-}
-
-.lse-theme-light .lse-loading {
-	background: rgba(255, 255, 255, 0.92);
 }

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -60,7 +60,7 @@ $quick_links = array(
 );
 
 ?>
-<div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox">
+<div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox" data-wp-class--lse-theme-light="state.isLightTheme">
 	<div class="lse-toolbar">
 		<button
 			type="button"

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -14,6 +14,24 @@ namespace Live_Sandbox_Editor;
 
 \defined( 'ABSPATH' ) || exit;
 
+$theme_options = array(
+	array(
+		'value'    => 'auto',
+		'label'    => __( 'Auto', 'live-sandbox-editor' ),
+		'is_state' => 'state.themeIsAuto',
+	),
+	array(
+		'value'    => 'light',
+		'label'    => __( 'Light', 'live-sandbox-editor' ),
+		'is_state' => 'state.themeIsLight',
+	),
+	array(
+		'value'    => 'dark',
+		'label'    => __( 'Dark', 'live-sandbox-editor' ),
+		'is_state' => 'state.themeIsDark',
+	),
+);
+
 $quick_links = array(
 	array(
 		'label' => __( 'Homepage', 'live-sandbox-editor' ),
@@ -114,6 +132,25 @@ $quick_links = array(
 				<div id="lse-file-tree-body" class="lse-file-tree-body" tabindex="-1"></div>
 			</div>
 			<div class="lse-monaco-section">
+				<div class="lse-editor-toolbar">
+					<div
+						class="lse-theme-toggle"
+						role="radiogroup"
+						aria-label="<?php esc_attr_e( 'Editor theme', 'live-sandbox-editor' ); ?>"
+					>
+						<?php foreach ( $theme_options as $option ) : ?>
+							<button
+								type="button"
+								role="radio"
+								class="lse-theme-toggle-option"
+								data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'value' => $option['value'] ) ) ); ?>"
+								data-wp-on--click="actions.setThemeMode"
+								data-wp-bind--aria-checked="<?php echo esc_attr( $option['is_state'] ); ?>"
+								data-wp-class--is-active="<?php echo esc_attr( $option['is_state'] ); ?>"
+							><?php echo esc_html( $option['label'] ); ?></button>
+						<?php endforeach; ?>
+					</div>
+				</div>
 				<div id="lse-tabs" class="lse-tabs"></div>
 				<div id="lse-monaco" class="lse-monaco-container"></div>
 			</div>
@@ -131,3 +168,5 @@ $quick_links = array(
 		<span data-wp-text="state.statusText"></span>
 	</div>
 </div>
+
+<!-- HOSTMARKER -->

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -60,7 +60,7 @@ $quick_links = array(
 );
 
 ?>
-<div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox" data-wp-class--lse-theme-light="state.isLightTheme">
+<div id="live-sandbox-editor-root" data-wp-interactive="live-sandbox-editor/sandbox" data-wp-style--color-scheme="state.colorScheme">
 	<div class="lse-toolbar">
 		<button
 			type="button"

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -16,8 +16,8 @@ namespace Live_Sandbox_Editor;
 
 $theme_options = array(
 	array(
-		'value'    => 'auto',
-		'label'    => __( 'Auto', 'live-sandbox-editor' ),
+		'value'    => 'system',
+		'label'    => __( 'System', 'live-sandbox-editor' ),
 		'is_state' => 'state.themeIsAuto',
 	),
 	array(

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import { store } from '@wordpress/interactivity';
 import { initFileExplorer } from './file-explorer.js';
 import { readFile, writeFile } from './filesystem.js';
 import type { SyncManifest } from './playground.js';
-import { sandbox } from './store.js';
+import { registerMonacoThemeSetter, sandbox } from './store.js';
 import type { OpenFile } from './types.js';
 
 type EditorMod = typeof import('./editor.js');
@@ -83,7 +83,8 @@ export async function initApp(
 					// editor.js side-effect-imports monaco-environment.js, so
 					// MonacoEnvironment is registered before monaco.editor.create().
 					const mod = await import('./editor.js');
-					mod.initEditor(monacoContainer);
+					mod.initEditor(monacoContainer, sandbox.state.effectiveTheme);
+					registerMonacoThemeSetter(mod.setEditorTheme);
 					// Always register the save command. The wrapper resolves
 					// `saveHandler` at Cmd-S press time, so initialising the
 					// editor before `saveHandler` is assigned (toggle clicked

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,15 +3,24 @@
 // bindings are in place when monaco's static graph initialises.
 import './monaco-environment.js';
 import * as monaco from 'monaco-editor';
+import type { EffectiveTheme } from './store.js';
+
+// Runtime imports from store.ts deliberately avoided: store.ts is in the
+// eager main.js chunk; if this lazy chunk imports it, the lazy `import()` URL
+// resolves without the WP enqueue `?ver=…` query and the browser instantiates
+// main.js twice (one per URL identity). app.ts wires the editor up after
+// init instead.
 
 let editor: monaco.editor.IStandaloneCodeEditor | null = null;
 const models = new Map<string, monaco.editor.ITextModel>();
 
 export function initEditor(
 	container: HTMLElement,
+	initialTheme: EffectiveTheme,
 ): monaco.editor.IStandaloneCodeEditor {
+	if (editor) return editor;
 	editor = monaco.editor.create(container, {
-		theme: 'vs-dark',
+		theme: initialTheme,
 		automaticLayout: true,
 		fontSize: 13,
 		lineHeight: 20,
@@ -20,6 +29,10 @@ export function initEditor(
 		renderLineHighlight: 'gutter',
 	});
 	return editor;
+}
+
+export function setEditorTheme(theme: EffectiveTheme): void {
+	monaco.editor.setTheme(theme);
 }
 
 export function loadFileIntoEditor(path: string, content: string): void {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,13 +3,21 @@ import type { PlaygroundClient } from '@wp-playground/client';
 import { initPlayground, type SyncManifest } from './playground.js';
 import { getAppData } from './types.js';
 
+export type ThemeMode = 'light' | 'dark' | 'auto';
+export type EffectiveTheme = 'vs' | 'vs-dark';
+
 export interface SandboxState {
 	url: string;
 	statusText: string;
 	isReady: boolean;
 	editorOpen: boolean;
 	urlMenuOpen: boolean;
+	themeMode: ThemeMode;
 	readonly notReady: boolean;
+	readonly effectiveTheme: EffectiveTheme;
+	readonly themeIsAuto: boolean;
+	readonly themeIsLight: boolean;
+	readonly themeIsDark: boolean;
 }
 
 interface SandboxStore {
@@ -21,11 +29,48 @@ interface SandboxStore {
 		toggleEditor(): void;
 		openUrlMenu(): void;
 		quickNavigate(): Generator<Promise<unknown>, void>;
+		setThemeMode(): void;
 		boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
 		): Generator<Promise<unknown>, PlaygroundClient | null>;
 	};
+}
+
+const THEME_STORAGE_KEY = 'lse-theme-mode';
+
+function isThemeMode(v: unknown): v is ThemeMode {
+	return v === 'light' || v === 'dark' || v === 'auto';
+}
+
+function readStoredThemeMode(): ThemeMode {
+	try {
+		const v = localStorage.getItem(THEME_STORAGE_KEY);
+		if (isThemeMode(v)) return v;
+	} catch {
+		// localStorage may be unavailable (privacy modes); fall through.
+	}
+	return 'auto';
+}
+
+const darkMediaQuery =
+	typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+		? window.matchMedia('(prefers-color-scheme: dark)')
+		: null;
+
+// Editor module registers a setter once Monaco is loaded so the store can
+// push theme changes without forcing the lazy `monaco-editor` chunk to load
+// before the user opens the editor.
+let monacoSetTheme: ((theme: EffectiveTheme) => void) | null = null;
+
+export function registerMonacoThemeSetter(
+	fn: (theme: EffectiveTheme) => void,
+): void {
+	monacoSetTheme = fn;
+}
+
+function applyMonacoTheme(): void {
+	monacoSetTheme?.(sandbox.state.effectiveTheme);
 }
 
 let client: PlaygroundClient | null = null;
@@ -42,8 +87,24 @@ let suppressNextOpen = false;
 // hydration.
 export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 	state: {
+		themeMode: readStoredThemeMode(),
 		get notReady(): boolean {
 			return !sandbox.state.isReady;
+		},
+		get effectiveTheme(): EffectiveTheme {
+			const mode = sandbox.state.themeMode;
+			if (mode === 'light') return 'vs';
+			if (mode === 'dark') return 'vs-dark';
+			return darkMediaQuery?.matches ? 'vs-dark' : 'vs';
+		},
+		get themeIsAuto(): boolean {
+			return sandbox.state.themeMode === 'auto';
+		},
+		get themeIsLight(): boolean {
+			return sandbox.state.themeMode === 'light';
+		},
+		get themeIsDark(): boolean {
+			return sandbox.state.themeMode === 'dark';
 		},
 	},
 	actions: {
@@ -64,6 +125,19 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		},
 		toggleEditor(): void {
 			sandbox.state.editorOpen = !sandbox.state.editorOpen;
+		},
+		setThemeMode(): void {
+			const { value } = getContext<{ value: unknown }>();
+			if (!isThemeMode(value)) return;
+			if (value === sandbox.state.themeMode) return;
+			sandbox.state.themeMode = value;
+			try {
+				localStorage.setItem(THEME_STORAGE_KEY, value);
+			} catch {
+				// Ignore quota / disabled-storage failures; in-memory state
+				// still reflects the user's choice for this session.
+			}
+			applyMonacoTheme();
 		},
 		openUrlMenu(): void {
 			if (suppressNextOpen) {
@@ -125,4 +199,11 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			return client;
 		},
 	},
+});
+
+// Live-follow OS appearance only when the user has chosen 'auto'. In manual
+// modes the listener fires but the effective theme doesn't change, so the
+// editor stays put.
+darkMediaQuery?.addEventListener('change', () => {
+	if (sandbox.state.themeMode === 'auto') applyMonacoTheme();
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,11 +13,13 @@ export interface SandboxState {
 	editorOpen: boolean;
 	urlMenuOpen: boolean;
 	themeMode: ThemeMode;
+	prefersDark: boolean;
 	readonly notReady: boolean;
 	readonly effectiveTheme: EffectiveTheme;
 	readonly themeIsAuto: boolean;
 	readonly themeIsLight: boolean;
 	readonly themeIsDark: boolean;
+	readonly isLightTheme: boolean;
 }
 
 interface SandboxStore {
@@ -88,6 +90,7 @@ let suppressNextOpen = false;
 export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 	state: {
 		themeMode: readStoredThemeMode(),
+		prefersDark: !!darkMediaQuery?.matches,
 		get notReady(): boolean {
 			return !sandbox.state.isReady;
 		},
@@ -95,7 +98,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			const mode = sandbox.state.themeMode;
 			if (mode === 'light') return 'vs';
 			if (mode === 'dark') return 'vs-dark';
-			return darkMediaQuery?.matches ? 'vs-dark' : 'vs';
+			return sandbox.state.prefersDark ? 'vs-dark' : 'vs';
 		},
 		get themeIsAuto(): boolean {
 			return sandbox.state.themeMode === 'auto';
@@ -105,6 +108,9 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		},
 		get themeIsDark(): boolean {
 			return sandbox.state.themeMode === 'dark';
+		},
+		get isLightTheme(): boolean {
+			return sandbox.state.effectiveTheme === 'vs';
 		},
 	},
 	actions: {
@@ -204,6 +210,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 // Live-follow OS appearance only when the user has chosen 'auto'. In manual
 // modes the listener fires but the effective theme doesn't change, so the
 // editor stays put.
-darkMediaQuery?.addEventListener('change', () => {
+darkMediaQuery?.addEventListener('change', (event) => {
+	sandbox.state.prefersDark = event.matches;
 	if (sandbox.state.themeMode === 'auto') applyMonacoTheme();
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,11 +80,11 @@ let client: PlaygroundClient | null = null;
 // focus event doesn't immediately reopen the menu we just closed.
 let suppressNextOpen = false;
 
-// Primitive initial values are authoritative in PHP via
+// Most primitive initial values are authoritative in PHP via
 // `wp_interactivity_state` (see live-sandbox-editor/live-sandbox-editor.php).
-// Only the derived `notReady` getter is declared here; the rest of the shape
-// is supplied by the `SandboxStore` generic and merged from server state at
-// hydration.
+// Exception: `themeMode` is user-specific (localStorage), so the server can't
+// know it — initialised here from `readStoredThemeMode()`. Derived getters
+// (`notReady`, `effectiveTheme`, `themeIs*`) are declared inline below.
 export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 	state: {
 		themeMode: readStoredThemeMode(),

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,7 +3,7 @@ import type { PlaygroundClient } from '@wp-playground/client';
 import { initPlayground, type SyncManifest } from './playground.js';
 import { getAppData } from './types.js';
 
-export type ThemeMode = 'light' | 'dark' | 'auto';
+export type ThemeMode = 'light' | 'dark' | 'system';
 export type EffectiveTheme = 'vs' | 'vs-dark';
 
 export interface SandboxState {
@@ -42,7 +42,7 @@ interface SandboxStore {
 const THEME_STORAGE_KEY = 'lse-theme-mode';
 
 function isThemeMode(v: unknown): v is ThemeMode {
-	return v === 'light' || v === 'dark' || v === 'auto';
+	return v === 'light' || v === 'dark' || v === 'system';
 }
 
 function readStoredThemeMode(): ThemeMode {
@@ -52,7 +52,7 @@ function readStoredThemeMode(): ThemeMode {
 	} catch {
 		// localStorage may be unavailable (privacy modes); fall through.
 	}
-	return 'auto';
+	return 'system';
 }
 
 const darkMediaQuery =
@@ -101,7 +101,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 			return sandbox.state.prefersDark ? 'vs-dark' : 'vs';
 		},
 		get themeIsAuto(): boolean {
-			return sandbox.state.themeMode === 'auto';
+			return sandbox.state.themeMode === 'system';
 		},
 		get themeIsLight(): boolean {
 			return sandbox.state.themeMode === 'light';
@@ -207,10 +207,10 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 	},
 });
 
-// Live-follow OS appearance only when the user has chosen 'auto'. In manual
+// Live-follow OS appearance only when the user has chosen 'system'. In manual
 // modes the listener fires but the effective theme doesn't change, so the
 // editor stays put.
 darkMediaQuery?.addEventListener('change', (event) => {
 	sandbox.state.prefersDark = event.matches;
-	if (sandbox.state.themeMode === 'auto') applyMonacoTheme();
+	if (sandbox.state.themeMode === 'system') applyMonacoTheme();
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,7 +19,7 @@ export interface SandboxState {
 	readonly themeIsAuto: boolean;
 	readonly themeIsLight: boolean;
 	readonly themeIsDark: boolean;
-	readonly isLightTheme: boolean;
+	readonly colorScheme: string;
 }
 
 interface SandboxStore {
@@ -109,8 +109,11 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		get themeIsDark(): boolean {
 			return sandbox.state.themeMode === 'dark';
 		},
-		get isLightTheme(): boolean {
-			return sandbox.state.effectiveTheme === 'vs';
+		get colorScheme(): string {
+			const mode = sandbox.state.themeMode;
+			if (mode === 'light') return 'light';
+			if (mode === 'dark') return 'dark';
+			return 'light dark';
 		},
 	},
 	actions: {


### PR DESCRIPTION
Adds an Auto/Light/Dark picker for the Monaco editor and extends the chosen theme to the file tree, tabs, toolbars, and status bar so the editor blends with wp-admin instead of staying VS-Code-dark. Light variant uses the wp-admin native palette (`#f0f0f1` surfaces, `#dcdcde` borders, `#1d2327` / `#50575e` text, `#2271b1` active highlight); Auto follows `prefers-color-scheme` reactively.

[Demo](https://cleanshot.com/share/kc5kSCYy)