### PR TITLE
Feature: test plugin update in sandbox

### DIFF
--- a/live-sandbox-editor/inc/test-upgrade.php
+++ b/live-sandbox-editor/inc/test-upgrade.php
@@ -23,7 +23,7 @@ function init(): void {
  * apply.
  */
 function register_update_message_hooks(): void {
-	if ( ! current_user_can( 'update_plugins' ) ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 	$updates = get_site_transient( 'update_plugins' );

--- a/live-sandbox-editor/inc/test-upgrade.php
+++ b/live-sandbox-editor/inc/test-upgrade.php
@@ -35,7 +35,9 @@ function register_update_message_hooks(): void {
 			'in_plugin_update_message-' . $entry,
 			static function () use ( $entry ): void {
 				render_link( (string) $entry );
-			}
+			},
+			10,
+			0
 		);
 	}
 }

--- a/live-sandbox-editor/inc/test-upgrade.php
+++ b/live-sandbox-editor/inc/test-upgrade.php
@@ -41,19 +41,23 @@ function register_update_message_hooks(): void {
 }
 
 /**
- * Echo the link inside the update-message paragraph. Leading space
- * separates it from the standard "View version X details" / "update now"
- * links that precede it.
+ * Echo the link inside the update-message paragraph. The `<br>` breaks it
+ * onto its own line below the standard "View version X details" / "update
+ * now" links so the sandbox-test offer reads as a distinct alternative.
  */
 function render_link( string $entry ): void {
 	$run_url = menu_page_url( Live_Sandbox_Editor\SLUG, false );
 	$href    = add_query_arg( 'testUpgrade', $entry, $run_url );
-	$label   = __( 'Test upgrade in sandbox', 'live-sandbox-editor' );
+	$label   = __( 'test the plugin update in the sandbox', 'live-sandbox-editor' );
 
 	printf(
-		' <a href="%s" class="lse-test-upgrade-link" data-lse-test-upgrade="%s">%s</a>',
-		esc_url( $href ),
-		esc_attr( $entry ),
-		esc_html( $label )
+		/* translators: %s: link to test the update in the Live Sandbox Editor. */
+		'<br>' . esc_html__( 'Or %s.', 'live-sandbox-editor' ),
+		sprintf(
+			'<a href="%s" class="lse-test-upgrade-link" data-lse-test-upgrade="%s">%s</a>',
+			esc_url( $href ),
+			esc_attr( $entry ),
+			esc_html( $label )
+		)
 	);
 }

--- a/live-sandbox-editor/inc/test-upgrade.php
+++ b/live-sandbox-editor/inc/test-upgrade.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * "Test upgrade in sandbox" — host-side link injection.
+ *
+ * @package LiveSandboxEditor
+ */
+
+namespace Live_Sandbox_Editor\Test_Upgrade;
+
+\defined( 'ABSPATH' ) || exit;
+
+use Live_Sandbox_Editor;
+
+/** Bootstraps the feature. Called from main plugin init(). */
+function init(): void {
+	add_action( 'admin_init', __NAMESPACE__ . '\\register_update_message_hooks' );
+}
+
+/**
+ * One closure per entry that currently has an advertised update. Reading
+ * the transient here (rather than per render) keeps the registration
+ * idempotent and avoids running the inner closure for plugins that don't
+ * apply.
+ */
+function register_update_message_hooks(): void {
+	if ( ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
+	$updates = get_site_transient( 'update_plugins' );
+	if ( ! is_object( $updates ) || empty( $updates->response ) || ! is_array( $updates->response ) ) {
+		return;
+	}
+	foreach ( array_keys( $updates->response ) as $entry ) {
+		add_action(
+			'in_plugin_update_message-' . $entry,
+			static function () use ( $entry ): void {
+				render_link( (string) $entry );
+			}
+		);
+	}
+}
+
+/**
+ * Echo the link inside the update-message paragraph. Leading space
+ * separates it from the standard "View version X details" / "update now"
+ * links that precede it.
+ */
+function render_link( string $entry ): void {
+	$run_url = menu_page_url( Live_Sandbox_Editor\SLUG, false );
+	$href    = add_query_arg( 'testUpgrade', rawurlencode( $entry ), $run_url );
+	$label   = __( 'Test upgrade in sandbox', 'live-sandbox-editor' );
+
+	printf(
+		' <a href="%s" class="lse-test-upgrade-link" data-lse-test-upgrade="%s">%s</a>',
+		esc_url( $href ),
+		esc_attr( $entry ),
+		esc_html( $label )
+	);
+}

--- a/live-sandbox-editor/inc/test-upgrade.php
+++ b/live-sandbox-editor/inc/test-upgrade.php
@@ -47,7 +47,7 @@ function register_update_message_hooks(): void {
  */
 function render_link( string $entry ): void {
 	$run_url = menu_page_url( Live_Sandbox_Editor\SLUG, false );
-	$href    = add_query_arg( 'testUpgrade', rawurlencode( $entry ), $run_url );
+	$href    = add_query_arg( 'testUpgrade', $entry, $run_url );
 	$label   = __( 'Test upgrade in sandbox', 'live-sandbox-editor' );
 
 	printf(

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -27,6 +27,7 @@ const VERSION    = '0.1';
 require_once __DIR__ . '/inc/sync-stream.php';
 require_once __DIR__ . '/inc/manifest.php';
 require_once __DIR__ . '/inc/class-wpdb-pdo-adapter.php';
+require_once __DIR__ . '/inc/test-upgrade.php';
 
 /**
  * Load vendored Reprint classes only if they are not already defined.
@@ -59,6 +60,7 @@ function init(): void {
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\register_menu' );
 	add_action( 'admin_notices', __NAMESPACE__ . '\\reprint_notice' );
+	Test_Upgrade\init();
 }
 
 /**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -145,6 +145,12 @@
 		by host WordPress. Same `lse_` prefix convention.
 		-->
 		<exclude-pattern>./src/uploads-passthrough\.mu\.php$</exclude-pattern>
+		<!--
+		`src/iframe-target-fix.mu.php` is the same shape: a Playground
+		mu-plugin loaded only inside the sandbox to strip `target="_parent"`
+		from upgrader action links. Same `lse_` prefix convention.
+		-->
+		<exclude-pattern>./src/iframe-target-fix\.mu\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.Files.FileName">

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,13 +3,14 @@ import { initFileExplorer } from './file-explorer.js';
 import { readFile, writeFile } from './filesystem.js';
 import type { SyncManifest } from './playground.js';
 import { sandbox } from './store.js';
-import type { OpenFile } from './types.js';
+import type { OpenFile, TestUpgradeRequest } from './types.js';
 
 type EditorMod = typeof import('./editor.js');
 
 export async function initApp(
 	root: HTMLElement,
 	manifestOverride?: SyncManifest,
+	testUpgrade?: TestUpgradeRequest,
 ): Promise<void> {
 	const tabStrip = mustQuery(root, '#lse-tabs');
 	const monacoContainer = mustQuery(root, '#lse-monaco');
@@ -147,7 +148,7 @@ export async function initApp(
 		},
 	});
 
-	const client = await sandbox.actions.boot(iframe, manifestOverride);
+	const client = await sandbox.actions.boot(iframe, manifestOverride, testUpgrade);
 	if (!client) return;
 
 	saveHandler = async (path, content) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -148,7 +148,11 @@ export async function initApp(
 		},
 	});
 
-	const client = await sandbox.actions.boot(iframe, manifestOverride, testUpgrade);
+	const client = await sandbox.actions.boot(
+		iframe,
+		manifestOverride,
+		testUpgrade,
+	);
 	if (!client) return;
 
 	saveHandler = async (path, content) => {

--- a/src/iframe-target-fix.mu.php
+++ b/src/iframe-target-fix.mu.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Live Sandbox Editor — strip target="_parent" from admin links.
+ *
+ * WP core hardcodes `target="_parent"` on a handful of admin navigation
+ * links (notably the post-upgrade "Go to Plugins page" link on
+ * update.php) — a leftover from the bulk-update iframe UI inside
+ * plugins.php. Playground's entire admin already runs in an iframe
+ * owned by the editor; `_parent` resolves to the editor's host page,
+ * so clicking the link navigates the host out of the sandbox UI.
+ *
+ * Stripped at click-time via a capturing delegated listener so dynamic
+ * content is covered too.
+ *
+ * @package Live_Sandbox_Editor
+ */
+
+add_action(
+	'admin_print_footer_scripts',
+	static function () {
+		?>
+<script>
+(function(){
+	document.addEventListener('click', function(e){
+		var t = e.target;
+		if (!t || !t.closest) return;
+		var a = t.closest('a[target="_parent"]');
+		if (a) a.removeAttribute('target');
+	}, true);
+})();
+</script>
+		<?php
+	}
+);

--- a/src/iframe-target-fix.mu.php
+++ b/src/iframe-target-fix.mu.php
@@ -14,6 +14,13 @@
  * @package Live_Sandbox_Editor
  */
 
+/**
+ * Strip `target="_parent"` from anchors in an upgrader/installer action list.
+ *
+ * @param array<string,string>|mixed $actions Action HTML keyed by slug.
+ *
+ * @return array<string,string>|mixed Filtered actions, or original value if not an array.
+ */
 function lse_strip_parent_target_actions( $actions ) {
 	if ( ! is_array( $actions ) ) {
 		return $actions;

--- a/src/iframe-target-fix.mu.php
+++ b/src/iframe-target-fix.mu.php
@@ -9,9 +9,6 @@
  * owned by the editor; `_parent` resolves to the editor's host page,
  * so clicking the link navigates the host out of the sandbox UI.
  *
- * Stripped at click-time via a capturing delegated listener so dynamic
- * content is covered too.
- *
  * @package Live_Sandbox_Editor
  */
 
@@ -22,11 +19,9 @@ add_action(
 <script>
 (function(){
 	document.addEventListener('click', function(e){
-		var t = e.target;
-		if (!t || !t.closest) return;
-		var a = t.closest('a[target="_parent"]');
+		var a = e.target instanceof Element ? e.target.closest('a[target="_parent"]') : null;
 		if (a) a.removeAttribute('target');
-	}, true);
+	}, { capture: true, passive: true });
 })();
 </script>
 		<?php

--- a/src/iframe-target-fix.mu.php
+++ b/src/iframe-target-fix.mu.php
@@ -1,29 +1,58 @@
 <?php
 /**
- * Live Sandbox Editor — strip target="_parent" from admin links.
+ * Live Sandbox Editor — strip target="_parent" from upgrader action links.
  *
- * WP core hardcodes `target="_parent"` on a handful of admin navigation
- * links (notably the post-upgrade "Go to Plugins page" link on
- * update.php) — a leftover from the bulk-update iframe UI inside
- * plugins.php. Playground's entire admin already runs in an iframe
- * owned by the editor; `_parent` resolves to the editor's host page,
- * so clicking the link navigates the host out of the sandbox UI.
+ * WP core hardcodes `target="_parent"` on the action links emitted by the
+ * plugin/theme upgrader and installer skins (a leftover from the bulk-update
+ * iframe UI inside plugins.php). Playground's entire admin already runs in
+ * an iframe owned by the editor; `_parent` resolves to the editor's host
+ * page, so clicking those links navigates the host out of the sandbox UI.
+ *
+ * Each emitting site filters its action array through a dedicated hook, so
+ * we intercept those and rewrite the HTML via the HTML API.
  *
  * @package Live_Sandbox_Editor
  */
 
-add_action(
-	'admin_print_footer_scripts',
-	static function () {
-		?>
-<script>
-(function(){
-	document.addEventListener('click', function(e){
-		var a = e.target instanceof Element ? e.target.closest('a[target="_parent"]') : null;
-		if (a) a.removeAttribute('target');
-	}, { capture: true, passive: true });
-})();
-</script>
-		<?php
+/**
+ * Remove target="_parent" from any anchor in each action HTML string.
+ *
+ * @param array $actions Action label => anchor HTML.
+ * @return array
+ */
+function lse_strip_parent_target_actions( $actions ) {
+	if ( ! is_array( $actions ) ) {
+		return $actions;
 	}
-);
+	foreach ( $actions as $key => $html ) {
+		if ( ! is_string( $html ) || false === strpos( $html, '_parent' ) ) {
+			continue;
+		}
+		$p = new WP_HTML_Tag_Processor( $html );
+		while ( $p->next_tag( 'a' ) ) {
+			if ( '_parent' === $p->get_attribute( 'target' ) ) {
+				$p->remove_attribute( 'target' );
+			}
+		}
+		$actions[ $key ] = $p->get_updated_html();
+	}
+	return $actions;
+}
+
+foreach (
+	array(
+		'update_plugin_complete_actions',
+		'update_bulk_plugins_complete_actions',
+		'update_theme_complete_actions',
+		'update_bulk_theme_complete_actions',
+		'update_translations_complete_actions',
+		'install_plugin_complete_actions',
+		'install_plugin_overwrite_actions',
+		'install_theme_complete_actions',
+		'install_theme_overwrite_actions',
+		'theme_install_actions',
+	) as $lse_hook
+) {
+	add_filter( $lse_hook, 'lse_strip_parent_target_actions' );
+}
+unset( $lse_hook );

--- a/src/iframe-target-fix.mu.php
+++ b/src/iframe-target-fix.mu.php
@@ -14,23 +14,18 @@
  * @package Live_Sandbox_Editor
  */
 
-/**
- * Remove target="_parent" from any anchor in each action HTML string.
- *
- * @param array $actions Action label => anchor HTML.
- * @return array
- */
 function lse_strip_parent_target_actions( $actions ) {
 	if ( ! is_array( $actions ) ) {
 		return $actions;
 	}
 	foreach ( $actions as $key => $html ) {
-		if ( ! is_string( $html ) || false === strpos( $html, '_parent' ) ) {
+		if ( ! is_string( $html ) || false === stripos( $html, '_parent' ) ) {
 			continue;
 		}
 		$p = new WP_HTML_Tag_Processor( $html );
 		while ( $p->next_tag( 'a' ) ) {
-			if ( '_parent' === $p->get_attribute( 'target' ) ) {
+			$target = $p->get_attribute( 'target' );
+			if ( is_string( $target ) && 0 === strcasecmp( $target, '_parent' ) ) {
 				$p->remove_attribute( 'target' );
 			}
 		}
@@ -39,20 +34,13 @@ function lse_strip_parent_target_actions( $actions ) {
 	return $actions;
 }
 
-foreach (
-	array(
-		'update_plugin_complete_actions',
-		'update_bulk_plugins_complete_actions',
-		'update_theme_complete_actions',
-		'update_bulk_theme_complete_actions',
-		'update_translations_complete_actions',
-		'install_plugin_complete_actions',
-		'install_plugin_overwrite_actions',
-		'install_theme_complete_actions',
-		'install_theme_overwrite_actions',
-		'theme_install_actions',
-	) as $lse_hook
-) {
-	add_filter( $lse_hook, 'lse_strip_parent_target_actions' );
-}
-unset( $lse_hook );
+add_filter( 'update_plugin_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'update_bulk_plugins_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'update_theme_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'update_bulk_theme_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'update_translations_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'install_plugin_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'install_plugin_overwrite_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'install_theme_complete_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'install_theme_overwrite_actions', 'lse_strip_parent_target_actions' );
+add_filter( 'theme_install_actions', 'lse_strip_parent_target_actions' );

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,14 @@ function parseTestUpgradeParam(): TestUpgradeRequest | undefined {
 		console.warn('[live-sandbox-editor] Ignoring malformed testUpgrade param.');
 		return undefined;
 	}
+	for (const segment of raw.split('/')) {
+		if (segment === '' || segment === '.' || segment === '..') {
+			console.warn(
+				'[live-sandbox-editor] Ignoring malformed testUpgrade param.',
+			);
+			return undefined;
+		}
+	}
 	return { entry: raw };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { initApp } from './app.js';
 import type { SyncManifest } from './playground.js';
+import type { TestUpgradeRequest } from './types.js';
 
 function parseManifestParam(): SyncManifest | undefined {
 	const raw = new URLSearchParams(window.location.search).get('manifest');
@@ -27,11 +28,25 @@ function parseManifestParam(): SyncManifest | undefined {
 	return parsed as SyncManifest;
 }
 
+function parseTestUpgradeParam(): TestUpgradeRequest | undefined {
+	const raw = new URLSearchParams(window.location.search).get('testUpgrade');
+	if (!raw) return undefined;
+	// Mirror is_safe_plugin_entry on the PHP side; defence in depth before
+	// the value flows into Playground PHP via client.run().
+	if (!/^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)?\.php$/.test(raw)) {
+		console.warn('[live-sandbox-editor] Ignoring malformed testUpgrade param.');
+		return undefined;
+	}
+	return { entry: raw };
+}
+
 const root = document.getElementById('live-sandbox-editor-root');
 if (!root) {
 	console.error('[live-sandbox-editor] Root element not found.');
 } else {
-	initApp(root, parseManifestParam()).catch((err: unknown) => {
-		console.error('[live-sandbox-editor] App init failed:', err);
-	});
+	initApp(root, parseManifestParam(), parseTestUpgradeParam()).catch(
+		(err: unknown) => {
+			console.error('[live-sandbox-editor] App init failed:', err);
+		},
+	);
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,5 +1,6 @@
 import type { PlaygroundClient } from '@wp-playground/client';
 import type { TestUpgradeRequest } from './types.js';
+import iframeTargetFixMuPhp from './iframe-target-fix.mu.php?raw';
 import postImportFixupsPhp from './post-import-fixups.php?raw';
 import { BatchedDiskFlusher, readSyncStream } from './streaming.js';
 import { getAppData } from './types.js';
@@ -420,6 +421,8 @@ async function applyPostImportFixups(
 	const docroot = await client.documentRoot;
 	await client.writeFile(FIXUPS_PATH, postImportFixupsPhp);
 
+	await installIframeTargetFix(client, docroot);
+
 	// URL rewrite is conditional on a DB sync — without one, Playground's
 	// default options shouldn't be smashed with the host's URLs.
 	if (dbContext) {
@@ -445,6 +448,23 @@ async function applyPostImportFixups(
 			require_once '${FIXUPS_PATH}';
 			lse_deactivate_self();
 			${reconcile}
+		`,
+	});
+}
+
+async function installIframeTargetFix(
+	client: PlaygroundClient,
+	docroot: string,
+): Promise<void> {
+	const muDir = `${docroot}/wp-content/mu-plugins`;
+	await client.run({
+		code: `<?php
+			$dir = ${phpStringLiteral(muDir)};
+			@mkdir( $dir, 0755, true );
+			file_put_contents(
+				$dir . '/lse-iframe-target-fix.php',
+				${phpStringLiteral(iframeTargetFixMuPhp)}
+			);
 		`,
 	});
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,4 +1,5 @@
 import type { PlaygroundClient } from '@wp-playground/client';
+import type { TestUpgradeRequest } from './types.js';
 import postImportFixupsPhp from './post-import-fixups.php?raw';
 import { BatchedDiskFlusher, readSyncStream } from './streaming.js';
 import { getAppData } from './types.js';
@@ -40,6 +41,7 @@ export async function initPlayground(
 	onStatus: (status: string) => void,
 	debug: DebugSettings,
 	manifestOverride?: SyncManifest,
+	testUpgrade?: TestUpgradeRequest,
 ): Promise<PlaygroundClient> {
 	const debugMode = debug.scriptDebug || debug.wpDebug;
 	const { startPlaygroundWeb } = await import('@wp-playground/client');
@@ -61,6 +63,9 @@ export async function initPlayground(
 	onStatus('Resolving sync manifest…');
 	const manifestResp = await fetchManifest();
 	const manifest = manifestOverride ?? manifestResp.manifest;
+	if (testUpgrade && !manifest.plugins.includes(testUpgrade.entry)) {
+		manifest.plugins = [...manifest.plugins, testUpgrade.entry];
+	}
 	const dbContext: ManifestResponse = { ...manifestResp, manifest };
 
 	if (debugMode) {
@@ -85,6 +90,12 @@ export async function initPlayground(
 
 	onStatus('Finalizing sandbox…');
 	await applyPostImportFixups(client, hasDb ? dbContext : null, onStatus);
+
+	if (testUpgrade) {
+		onStatus('Preparing upgrade test…');
+		const { runTestUpgrade } = await import('./test-upgrade.js');
+		await runTestUpgrade(client, testUpgrade, onStatus);
+	}
 
 	return client;
 }

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -456,10 +456,17 @@ async function installIframeTargetFix(
 	client: PlaygroundClient,
 	docroot: string,
 ): Promise<void> {
-	await client.writeFile(
-		`${docroot}/wp-content/mu-plugins/lse-iframe-target-fix.php`,
-		iframeTargetFixMuPhp,
-	);
+	const muDir = `${docroot}/wp-content/mu-plugins`;
+	await client.run({
+		code: `<?php
+			$dir = ${phpStringLiteral(muDir)};
+			@mkdir( $dir, 0755, true );
+			file_put_contents(
+				$dir . '/lse-iframe-target-fix.php',
+				${phpStringLiteral(iframeTargetFixMuPhp)}
+			);
+		`,
+	});
 }
 
 /**

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -91,12 +91,6 @@ export async function initPlayground(
 	onStatus('Finalizing sandbox…');
 	await applyPostImportFixups(client, hasDb ? dbContext : null, onStatus);
 
-	if (testUpgrade) {
-		onStatus('Preparing upgrade test…');
-		const { runTestUpgrade } = await import('./test-upgrade.js');
-		await runTestUpgrade(client, testUpgrade, onStatus);
-	}
-
 	return client;
 }
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -456,17 +456,10 @@ async function installIframeTargetFix(
 	client: PlaygroundClient,
 	docroot: string,
 ): Promise<void> {
-	const muDir = `${docroot}/wp-content/mu-plugins`;
-	await client.run({
-		code: `<?php
-			$dir = ${phpStringLiteral(muDir)};
-			@mkdir( $dir, 0755, true );
-			file_put_contents(
-				$dir . '/lse-iframe-target-fix.php',
-				${phpStringLiteral(iframeTargetFixMuPhp)}
-			);
-		`,
-	});
+	await client.writeFile(
+		`${docroot}/wp-content/mu-plugins/lse-iframe-target-fix.php`,
+		iframeTargetFixMuPhp,
+	);
 }
 
 /**

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,8 +1,8 @@
 import type { PlaygroundClient } from '@wp-playground/client';
-import type { TestUpgradeRequest } from './types.js';
 import iframeTargetFixMuPhp from './iframe-target-fix.mu.php?raw';
 import postImportFixupsPhp from './post-import-fixups.php?raw';
 import { BatchedDiskFlusher, readSyncStream } from './streaming.js';
+import type { TestUpgradeRequest } from './types.js';
 import { getAppData } from './types.js';
 import uploadsPassthroughMuPhp from './uploads-passthrough.mu.php?raw';
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -126,6 +126,24 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 				sandbox.state.url = path;
 			});
 
+			// Test-upgrade flow runs after the post-amble so the terminal
+			// status it sets isn't clobbered, and so the iframe refresh that
+			// applies post-import fixups happens before the upgrade dispatch
+			// renavigates.
+			if (testUpgrade) {
+				sandbox.state.statusText = 'Preparing upgrade test…';
+				const mod = (yield import(
+					'./test-upgrade.js'
+				)) as typeof import('./test-upgrade.js');
+				yield mod.runTestUpgrade(
+					client,
+					testUpgrade,
+					(s: string) => {
+						sandbox.state.statusText = s;
+					},
+				);
+			}
+
 			return client;
 		},
 	},

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { getContext, store } from '@wordpress/interactivity';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { initPlayground, type SyncManifest } from './playground.js';
 import { getAppData } from './types.js';
+import type { TestUpgradeRequest } from './types.js';
 
 export interface SandboxState {
 	url: string;
@@ -24,6 +25,7 @@ interface SandboxStore {
 		boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
+			testUpgrade?: TestUpgradeRequest,
 		): Generator<Promise<unknown>, PlaygroundClient | null>;
 	};
 }
@@ -92,6 +94,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 		*boot(
 			iframe: HTMLIFrameElement,
 			manifestOverride?: SyncManifest,
+			testUpgrade?: TestUpgradeRequest,
 		): Generator<Promise<unknown>, PlaygroundClient | null> {
 			const { scriptDebug, wpDebug } = getAppData();
 			try {
@@ -102,6 +105,7 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 					},
 					{ scriptDebug, wpDebug },
 					manifestOverride,
+					testUpgrade,
 				)) as PlaygroundClient;
 			} catch (err) {
 				sandbox.state.statusText = 'Playground failed to initialize.';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,8 +1,8 @@
 import { getContext, store } from '@wordpress/interactivity';
 import type { PlaygroundClient } from '@wp-playground/client';
 import { initPlayground, type SyncManifest } from './playground.js';
-import { getAppData } from './types.js';
 import type { TestUpgradeRequest } from './types.js';
+import { getAppData } from './types.js';
 
 export interface SandboxState {
 	url: string;
@@ -136,21 +136,13 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 					'./test-upgrade.js'
 				)) as typeof import('./test-upgrade.js');
 				try {
-					yield mod.runTestUpgrade(
-						client,
-						testUpgrade,
-						(s: string) => {
-							sandbox.state.statusText = s;
-						},
-					);
+					yield mod.runTestUpgrade(client, testUpgrade, (s: string) => {
+						sandbox.state.statusText = s;
+					});
 				} catch (err) {
-					const message =
-						err instanceof Error ? err.message : String(err);
+					const message = err instanceof Error ? err.message : String(err);
 					sandbox.state.statusText = `Upgrade test failed: ${message}`;
-					console.error(
-						'[live-sandbox-editor] runTestUpgrade error:',
-						err,
-					);
+					console.error('[live-sandbox-editor] runTestUpgrade error:', err);
 				}
 			}
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -135,13 +135,23 @@ export const sandbox = store<SandboxStore>('live-sandbox-editor/sandbox', {
 				const mod = (yield import(
 					'./test-upgrade.js'
 				)) as typeof import('./test-upgrade.js');
-				yield mod.runTestUpgrade(
-					client,
-					testUpgrade,
-					(s: string) => {
-						sandbox.state.statusText = s;
-					},
-				);
+				try {
+					yield mod.runTestUpgrade(
+						client,
+						testUpgrade,
+						(s: string) => {
+							sandbox.state.statusText = s;
+						},
+					);
+				} catch (err) {
+					const message =
+						err instanceof Error ? err.message : String(err);
+					sandbox.state.statusText = `Upgrade test failed: ${message}`;
+					console.error(
+						'[live-sandbox-editor] runTestUpgrade error:',
+						err,
+					);
+				}
 			}
 
 			return client;

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -1,0 +1,13 @@
+// Placeholder — full implementation added in Task 3.
+// Rolldown (Vite 8) resolves dynamic imports at build time, so the module
+// must exist. This stub is replaced by the real implementation in Task 3.
+import type { PlaygroundClient } from '@wp-playground/client';
+import type { TestUpgradeRequest } from './types.js';
+
+export async function runTestUpgrade(
+	_client: PlaygroundClient,
+	_request: TestUpgradeRequest,
+	_onStatus: (status: string) => void,
+): Promise<void> {
+	throw new Error('runTestUpgrade: not yet implemented (Task 3)');
+}

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -1,13 +1,100 @@
-// Placeholder — full implementation added in Task 3.
-// Rolldown (Vite 8) resolves dynamic imports at build time, so the module
-// must exist. This stub is replaced by the real implementation in Task 3.
 import type { PlaygroundClient } from '@wp-playground/client';
 import type { TestUpgradeRequest } from './types.js';
 
 export async function runTestUpgrade(
-	_client: PlaygroundClient,
-	_request: TestUpgradeRequest,
-	_onStatus: (status: string) => void,
+	client: PlaygroundClient,
+	req: TestUpgradeRequest,
+	onStatus: (status: string) => void,
 ): Promise<void> {
-	throw new Error('runTestUpgrade: not yet implemented (Task 3)');
+	const docroot = await client.documentRoot;
+
+	onStatus('Refreshing plugin updates…');
+	const refresh = await refreshUpdates(client, docroot, req.entry);
+	if (!refresh.found) {
+		onStatus(
+			`No update advertised for ${req.entry} — Playground couldn't resolve it.`,
+		);
+		// Best effort: still navigate to plugins.php so the user can see
+		// the state for themselves.
+		await client.goTo('/wp-admin/plugins.php');
+		return;
+	}
+
+	onStatus('Triggering upgrade…');
+	const nonce = await mintUpgradeNonce(client, docroot, req.entry);
+
+	// Show plugins.php first so the "There is a new version" row is visible
+	// for one beat before the upgrade screen takes over. The 800 ms delay is
+	// intentional UX, not a sync boundary.
+	await client.goTo('/wp-admin/plugins.php');
+	await sleep(800);
+
+	const params = new URLSearchParams({
+		action: 'upgrade-plugin',
+		plugin: req.entry,
+		_wpnonce: nonce,
+	});
+	await client.goTo(`/wp-admin/update.php?${params.toString()}`);
+
+	onStatus('Upgrade in progress — see iframe.');
+}
+
+interface RefreshResult {
+	found: boolean;
+	newVersion: string | null;
+}
+
+async function refreshUpdates(
+	client: PlaygroundClient,
+	docroot: string,
+	entry: string,
+): Promise<RefreshResult> {
+	const result = await client.run({
+		code: `<?php
+			require '${docroot}/wp-load.php';
+			wp_set_current_user(1);
+			delete_site_transient('update_plugins');
+			if (!function_exists('wp_update_plugins')) {
+				require_once ABSPATH . 'wp-admin/includes/update.php';
+			}
+			wp_update_plugins();
+			$updates = get_site_transient('update_plugins');
+			$entry = ${phpStr(entry)};
+			$found = is_object($updates) && !empty($updates->response[$entry]);
+			$new_version = null;
+			if ($found && isset($updates->response[$entry]->new_version)) {
+				$new_version = (string) $updates->response[$entry]->new_version;
+			}
+			echo json_encode(array('found' => $found, 'newVersion' => $new_version));
+		`,
+	});
+	const parsed = JSON.parse(result.text) as RefreshResult;
+	return parsed;
+}
+
+async function mintUpgradeNonce(
+	client: PlaygroundClient,
+	docroot: string,
+	entry: string,
+): Promise<string> {
+	const result = await client.run({
+		code: `<?php
+			require '${docroot}/wp-load.php';
+			wp_set_current_user(1);
+			echo wp_create_nonce('upgrade-plugin_' . ${phpStr(entry)});
+		`,
+	});
+	const nonce = result.text.trim();
+	if (!/^[a-f0-9]{8,}$/i.test(nonce)) {
+		throw new Error(`Failed to mint upgrade nonce; got: ${nonce.slice(0, 80)}`);
+	}
+	return nonce;
+}
+
+function phpStr(s: string): string {
+	return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
 }

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -12,7 +12,7 @@ export async function runTestUpgrade(
 	const refresh = await refreshUpdates(client, docroot, req.entry);
 	if (!refresh.found) {
 		onStatus(
-			`No update advertised for ${req.entry} — Playground couldn't resolve it.`,
+			`No update advertised for ${req.entry}. Playground couldn't resolve it.`,
 		);
 		// Best effort: still navigate to plugins.php so the user can see
 		// the state for themselves.
@@ -20,7 +20,8 @@ export async function runTestUpgrade(
 		return;
 	}
 
-	onStatus('Triggering upgrade…');
+	const versionLabel = refresh.newVersion ? `to ${refresh.newVersion} ` : '';
+	onStatus(`Triggering upgrade ${versionLabel}…`);
 	const nonce = await mintUpgradeNonce(client, docroot, req.entry);
 
 	// Show plugins.php first so the "There is a new version" row is visible
@@ -36,7 +37,7 @@ export async function runTestUpgrade(
 	});
 	await client.goTo(`/wp-admin/update.php?${params.toString()}`);
 
-	onStatus('Upgrade in progress — see iframe.');
+	onStatus('Upgrade in progress. See iframe.');
 }
 
 interface RefreshResult {
@@ -51,7 +52,7 @@ async function refreshUpdates(
 ): Promise<RefreshResult> {
 	const result = await client.run({
 		code: `<?php
-			require '${docroot}/wp-load.php';
+			require ${phpStr(docroot)} . '/wp-load.php';
 			wp_set_current_user(1);
 			delete_site_transient('update_plugins');
 			if (!function_exists('wp_update_plugins')) {
@@ -68,8 +69,13 @@ async function refreshUpdates(
 			echo json_encode(array('found' => $found, 'newVersion' => $new_version));
 		`,
 	});
-	const parsed = JSON.parse(result.text) as RefreshResult;
-	return parsed;
+	try {
+		return JSON.parse(result.text) as RefreshResult;
+	} catch (err) {
+		throw new Error(
+			`refreshUpdates: failed to parse PHP response (${result.text.slice(0, 200)})`,
+		);
+	}
 }
 
 async function mintUpgradeNonce(
@@ -79,7 +85,7 @@ async function mintUpgradeNonce(
 ): Promise<string> {
 	const result = await client.run({
 		code: `<?php
-			require '${docroot}/wp-load.php';
+			require ${phpStr(docroot)} . '/wp-load.php';
 			wp_set_current_user(1);
 			echo wp_create_nonce('upgrade-plugin_' . ${phpStr(entry)});
 		`,

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -6,10 +6,8 @@ export async function runTestUpgrade(
 	req: TestUpgradeRequest,
 	onStatus: (status: string) => void,
 ): Promise<void> {
-	const docroot = await client.documentRoot;
-
 	onStatus('Triggering upgrade…');
-	const nonce = await mintUpgradeNonce(client, docroot, req.entry);
+	const upgradeUrl = await findUpgradeUrl(client, req.entry);
 
 	// Show plugins.php first so the "There is a new version" row is visible
 	// for one beat before the upgrade screen takes over. The 800 ms delay is
@@ -17,37 +15,41 @@ export async function runTestUpgrade(
 	await client.goTo('/wp-admin/plugins.php');
 	await sleep(800);
 
-	const params = new URLSearchParams({
-		action: 'upgrade-plugin',
-		plugin: req.entry,
-		_wpnonce: nonce,
-	});
-	await client.goTo(`/wp-admin/update.php?${params.toString()}`);
-
+	await client.goTo(upgradeUrl);
 	onStatus('Upgrade in progress. See iframe.');
 }
 
-async function mintUpgradeNonce(
+/**
+ * Locate the per-row upgrade link in plugins.php and return its href
+ * (including the embedded nonce). Fetching the HTML via `client.request`
+ * runs the PHP request inside the iframe's auth session, so the rendered
+ * `_wpnonce` matches what `update.php` will expect from the iframe's own
+ * navigation. Minting the nonce via `client.run()` would use a different
+ * session token (no LOGGED_IN cookie) and trip "link expired."
+ */
+async function findUpgradeUrl(
 	client: PlaygroundClient,
-	docroot: string,
 	entry: string,
 ): Promise<string> {
-	const result = await client.run({
-		code: `<?php
-			require ${phpStr(docroot)} . '/wp-load.php';
-			wp_set_current_user(1);
-			echo wp_create_nonce('upgrade-plugin_' . ${phpStr(entry)});
-		`,
-	});
-	const nonce = result.text.trim();
-	if (!/^[a-f0-9]{8,}$/i.test(nonce)) {
-		throw new Error(`Failed to mint upgrade nonce; got: ${nonce.slice(0, 80)}`);
+	const response = await client.request({ url: '/wp-admin/plugins.php' });
+	const html = response.text;
+
+	const encodedEntry = encodeURIComponent(entry);
+	const re = new RegExp(
+		`update\\.php\\?action=upgrade-plugin&(?:amp;)?plugin=${escapeRegex(encodedEntry)}&(?:amp;)?_wpnonce=([a-f0-9]+)`,
+		'i',
+	);
+	const match = html.match(re);
+	if (!match) {
+		throw new Error(
+			`No upgrade link found on plugins.php for ${entry}. The transferred update_plugins transient may have been overwritten or the plugin isn't installed in Playground.`,
+		);
 	}
-	return nonce;
+	return `/wp-admin/update.php?action=upgrade-plugin&plugin=${encodedEntry}&_wpnonce=${match[1]}`;
 }
 
-function phpStr(s: string): string {
-	return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -8,20 +8,7 @@ export async function runTestUpgrade(
 ): Promise<void> {
 	const docroot = await client.documentRoot;
 
-	onStatus('Refreshing plugin updates…');
-	const refresh = await refreshUpdates(client, docroot, req.entry);
-	if (!refresh.found) {
-		onStatus(
-			`No update advertised for ${req.entry}. Playground couldn't resolve it.`,
-		);
-		// Best effort: still navigate to plugins.php so the user can see
-		// the state for themselves.
-		await client.goTo('/wp-admin/plugins.php');
-		return;
-	}
-
-	const versionLabel = refresh.newVersion ? `to ${refresh.newVersion} ` : '';
-	onStatus(`Triggering upgrade ${versionLabel}…`);
+	onStatus('Triggering upgrade…');
 	const nonce = await mintUpgradeNonce(client, docroot, req.entry);
 
 	// Show plugins.php first so the "There is a new version" row is visible
@@ -38,44 +25,6 @@ export async function runTestUpgrade(
 	await client.goTo(`/wp-admin/update.php?${params.toString()}`);
 
 	onStatus('Upgrade in progress. See iframe.');
-}
-
-interface RefreshResult {
-	found: boolean;
-	newVersion: string | null;
-}
-
-async function refreshUpdates(
-	client: PlaygroundClient,
-	docroot: string,
-	entry: string,
-): Promise<RefreshResult> {
-	const result = await client.run({
-		code: `<?php
-			require ${phpStr(docroot)} . '/wp-load.php';
-			wp_set_current_user(1);
-			delete_site_transient('update_plugins');
-			if (!function_exists('wp_update_plugins')) {
-				require_once ABSPATH . 'wp-admin/includes/update.php';
-			}
-			wp_update_plugins();
-			$updates = get_site_transient('update_plugins');
-			$entry = ${phpStr(entry)};
-			$found = is_object($updates) && !empty($updates->response[$entry]);
-			$new_version = null;
-			if ($found && isset($updates->response[$entry]->new_version)) {
-				$new_version = (string) $updates->response[$entry]->new_version;
-			}
-			echo json_encode(array('found' => $found, 'newVersion' => $new_version));
-		`,
-	});
-	try {
-		return JSON.parse(result.text) as RefreshResult;
-	} catch (err) {
-		throw new Error(
-			`refreshUpdates: failed to parse PHP response (${result.text.slice(0, 200)})`,
-		);
-	}
 }
 
 async function mintUpgradeNonce(

--- a/src/test-upgrade.ts
+++ b/src/test-upgrade.ts
@@ -32,14 +32,16 @@ async function findUpgradeUrl(
 	entry: string,
 ): Promise<string> {
 	const response = await client.request({ url: '/wp-admin/plugins.php' });
-	const html = response.text;
+	// esc_url() can emit either &amp; or &#038; for query separators in admin
+	// link hrefs. Normalize to plain & so a single regex covers both forms.
+	const normalized = response.text.replace(/&(?:amp;|#038;)/g, '&');
 
 	const encodedEntry = encodeURIComponent(entry);
 	const re = new RegExp(
-		`update\\.php\\?action=upgrade-plugin&(?:amp;)?plugin=${escapeRegex(encodedEntry)}&(?:amp;)?_wpnonce=([a-f0-9]+)`,
+		`update\\.php\\?action=upgrade-plugin&plugin=${escapeRegex(encodedEntry)}&_wpnonce=([a-f0-9]+)`,
 		'i',
 	);
-	const match = html.match(re);
+	const match = normalized.match(re);
 	if (!match) {
 		throw new Error(
 			`No upgrade link found on plugins.php for ${entry}. The transferred update_plugins transient may have been overwritten or the plugin isn't installed in Playground.`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,10 @@ export interface AppData {
 	wpDebug: boolean;
 }
 
+export interface TestUpgradeRequest {
+	entry: string;
+}
+
 export function getAppData(moduleId = 'live-sandbox-editor'): AppData {
 	const el = document.getElementById(`wp-script-module-data-${moduleId}`);
 	return JSON.parse(el?.textContent ?? '{}') as AppData;


### PR DESCRIPTION
This implements a feature that will allow users to test a plugin update (themes not part of this PR yet) in the sandbox.

When a plugin update is available, the user will see a new action available in the Plugins' page allowing them to test the plugin update in the sandbox directly:
- the link will run a sandbox that will include the plugin
- take the Playground directly to the plugin's update screen
- run the plugin update 
- leave the user in the post-plugin update screen

The feature works whether the plugin is currently active on the host site or not.
If not active, then the feature will honor the user intent by updating the plugin and letting the user decide whether they want to activate the plugin or not.

- [Demo](https://cleanshot.com/share/2KC7jB35)

I'm using the Performance Lab plugin to test the feature and this command to reset the state between tests:
```bash
wp-env run cli wp plugin uninstall performance-lab --deactivate;\
wp-env run cli wp plugin install https://downloads.wordpress.org/plugin/performance-lab.3.9.0.zip --activate --force &&\
wp-env run cli wp transient delete update_plugins &&\
wp-env run cli wp plugin list --update=available
```
