### PR TITLE
Add Plugin Check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,20 @@ jobs:
 
       - name: Check PHP coding standards (src/)
         run: composer lint:src
+
+  plugin-check:
+    name: Plugin Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Plugin Check
+        uses: WordPress/plugin-check-action@v1
+        with:
+          build-dir: ./live-sandbox-editor
+          strict: true

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,6 +6,9 @@
 		"SCRIPT_DEBUG": true,
 		"WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
 	},
-	"plugins": ["./live-sandbox-editor"],
+	"plugins": [
+		"./live-sandbox-editor",
+		"https://downloads.wordpress.org/plugin/plugin-check.zip"
+	],
 	"testsEnvironment": false
 }

--- a/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-adapter.php
@@ -48,7 +48,7 @@ class Wpdb_Pdo_Adapter {
 		$charset = ( isset( $wpdb->charset ) && '' !== $wpdb->charset ) ? $wpdb->charset : 'utf8mb4';
 		// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_set_charset -- intentional: wpdb's $charset reflects the desired connection charset, but on hosts where wpdb didn't get to call set_charset() we still need to pin it so mysqli_real_escape_string() is well-defined.
 		if ( ! \mysqli_set_charset( $wpdb->dbh, $charset ) ) {
-			throw new \PDOException( 'Wpdb_Pdo_Adapter could not set connection charset to ' . $charset . '.' );
+			throw new \PDOException( esc_html( 'Wpdb_Pdo_Adapter could not set connection charset to ' . $charset . '.' ) );
 		}
 
 		// Reject session modes that invalidate the assumptions baked into
@@ -69,7 +69,7 @@ class Wpdb_Pdo_Adapter {
 		$mode = (string) $rows[0][0];
 		foreach ( array( 'NO_BACKSLASH_ESCAPES', 'ANSI_QUOTES' ) as $forbidden ) {
 			if ( false !== stripos( $mode, $forbidden ) ) {
-				throw new \PDOException( 'Wpdb_Pdo_Adapter cannot run with ' . $forbidden . ' sql_mode.' );
+				throw new \PDOException( esc_html( 'Wpdb_Pdo_Adapter cannot run with ' . $forbidden . ' sql_mode.' ) );
 			}
 		}
 
@@ -114,6 +114,6 @@ class Wpdb_Pdo_Adapter {
 	 *                       through the existing PDOException handlers.
 	 */
 	public function __call( string $name, array $args ) {
-		throw new \PDOException( 'Wpdb_Pdo_Adapter does not implement ' . $name . '()' );
+		throw new \PDOException( esc_html( 'Wpdb_Pdo_Adapter does not implement ' . $name . '()' ) );
 	}
 }

--- a/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
@@ -62,7 +62,7 @@ class Wpdb_Pdo_Statement {
 		// fresh failure even when get_results returns an empty array.
 		$this->wpdb->last_error = '';
 		try {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter -- placeholders already substituted via PDO::quote()-equivalent escaping in substitute_placeholders() above; calling wpdb::prepare() here would corrupt the SQL.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter -- $sql is the output of substitute_placeholders(), which is safe for the MySQLDumpProducer SQL subset documented above (placeholder-only templates; no in-template literals or comments to misframe); calling wpdb::prepare() here would corrupt the SQL.
 			$result = $this->wpdb->get_results( $sql, ARRAY_A );
 
 			if ( '' !== (string) $this->wpdb->last_error ) {

--- a/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
+++ b/live-sandbox-editor/inc/class-wpdb-pdo-statement.php
@@ -62,7 +62,7 @@ class Wpdb_Pdo_Statement {
 		// fresh failure even when get_results returns an empty array.
 		$this->wpdb->last_error = '';
 		try {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- placeholders already substituted via PDO::quote()-equivalent escaping above; calling wpdb::prepare() here would corrupt the SQL.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter -- placeholders already substituted via PDO::quote()-equivalent escaping in substitute_placeholders() above; calling wpdb::prepare() here would corrupt the SQL.
 			$result = $this->wpdb->get_results( $sql, ARRAY_A );
 
 			if ( '' !== (string) $this->wpdb->last_error ) {
@@ -193,9 +193,12 @@ class Wpdb_Pdo_Statement {
 	}
 
 	/**
+	 * @param int $mode PDO fetch mode — unused; adapter always returns
+	 *                  associative rows. Literal `2` mirrors `\PDO::FETCH_ASSOC`
+	 *                  so callers passing the PDO constant land on the default.
 	 * @return array<string,mixed>|false Next row, or false when exhausted.
 	 */
-	public function fetch( int $mode = \PDO::FETCH_ASSOC ) {
+	public function fetch( int $mode = 2 ) {
 		if ( $this->position >= count( $this->rows ) ) {
 			return false;
 		}
@@ -222,9 +225,10 @@ class Wpdb_Pdo_Statement {
 	 * @param mixed      $value     Value to bind.
 	 * @param int        $type      PDO param type — ignored: `quote()` infers
 	 *                              from the PHP type and the producer never
-	 *                              reads it back.
+	 *                              reads it back. Literal `2` mirrors
+	 *                              `\PDO::PARAM_STR`.
 	 */
-	public function bindValue( $parameter, $value, int $type = \PDO::PARAM_STR ): bool {
+	public function bindValue( $parameter, $value, int $type = 2 ): bool {
 		if ( null === $this->bound_params ) {
 			$this->bound_params = array();
 		}
@@ -237,6 +241,6 @@ class Wpdb_Pdo_Statement {
 	 * @throws \PDOException Always.
 	 */
 	public function __call( string $name, array $args ) {
-		throw new \PDOException( 'Wpdb_Pdo_Statement does not implement ' . $name . '()' );
+		throw new \PDOException( esc_html( 'Wpdb_Pdo_Statement does not implement ' . $name . '()' ) );
 	}
 }

--- a/live-sandbox-editor/inc/manifest.php
+++ b/live-sandbox-editor/inc/manifest.php
@@ -23,6 +23,8 @@
 
 namespace Live_Sandbox_Editor\Manifest;
 
+\defined( 'ABSPATH' ) || exit;
+
 /**
  * Default manifest: active plugins, active theme + parent, structural (core
  * WP) tables, no uploads.

--- a/live-sandbox-editor/inc/sync-stream.php
+++ b/live-sandbox-editor/inc/sync-stream.php
@@ -22,6 +22,8 @@
 
 namespace Live_Sandbox_Editor\Sync_Stream;
 
+\defined( 'ABSPATH' ) || exit;
+
 const MARKER_FILE = 'FILE';
 const MARKER_SQL  = 'SQL';
 const MARKER_END  = 'END';
@@ -36,7 +38,7 @@ function setup(): void {
 	while ( ob_get_level() > 0 ) {
 		ob_end_clean();
 	}
-	// phpcs:ignore WordPress.PHP.IniSet.Risky,WordPress.PHP.NoSilencedErrors.Discouraged -- intentional: streaming response, output buffering / compression must be off; ini_set may be disabled on some hosts.
+	// phpcs:ignore WordPress.PHP.IniSet.Risky,WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional: streaming response, output buffering / compression must be off; ini_set may be disabled on some hosts.
 	@ini_set( 'zlib.output_compression', '0' );
 	if ( function_exists( 'apache_setenv' ) ) {
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_apache_setenv -- intentional: streaming response, gzip must be off; apache_setenv is the only way to force this on mod_php.
@@ -45,7 +47,7 @@ function setup(): void {
 	// Streaming a full export comfortably exceeds the default 30s
 	// max_execution_time. Disable up front and reset periodically — some
 	// hosts silently re-impose a per-iteration timer.
-	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional: streaming a full export comfortably exceeds the default 30s max_execution_time; the silence covers set_time_limit being disabled in php.ini.
 	@set_time_limit( 0 );
 	ignore_user_abort( true );
 	if ( function_exists( 'session_write_close' ) ) {

--- a/live-sandbox-editor/inc/sync-stream.php
+++ b/live-sandbox-editor/inc/sync-stream.php
@@ -35,8 +35,14 @@ const MARKER_ERR  = 'ERR';
  * unmodified.
  */
 function setup(): void {
+	// Bail on non-removable buffers (PHP's `output_buffering` ini, an
+	// extension-installed buffer) so we don't spin forever on a level
+	// ob_end_clean() refuses to pop.
 	while ( ob_get_level() > 0 ) {
-		ob_end_clean();
+		$status = ob_get_status();
+		if ( empty( $status['del'] ) || ! ob_end_clean() ) {
+			break;
+		}
 	}
 	// phpcs:ignore WordPress.PHP.IniSet.Risky,WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional: streaming response, output buffering / compression must be off; ini_set may be disabled on some hosts.
 	@ini_set( 'zlib.output_compression', '0' );

--- a/live-sandbox-editor/live-sandbox-editor.php
+++ b/live-sandbox-editor/live-sandbox-editor.php
@@ -16,6 +16,8 @@
 
 namespace Live_Sandbox_Editor;
 
+\defined( 'ABSPATH' ) || exit;
+
 use FileTreeProducer;
 use WP_REST_Request;
 use WordPress\DataLiberation\MySQLDumpProducer;
@@ -475,7 +477,7 @@ function rest_sync_files( WP_REST_Request $request ): void {
 
 			++$emitted;
 			if ( 0 === ( $emitted % 64 ) ) {
-				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional: streaming loop, default max_execution_time would terminate large exports; the silence covers set_time_limit being disabled in php.ini.
 				@set_time_limit( 0 );
 				if ( connection_aborted() ) {
 					exit;
@@ -611,7 +613,7 @@ function rest_sync_db( WP_REST_Request $request ): void {
 
 			++$emitted;
 			if ( 0 === ( $emitted % 64 ) ) {
-				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled in php.ini; the silence is the intended fallback.
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,Squiz.PHP.DiscouragedFunctions.Discouraged -- intentional: streaming loop, default max_execution_time would terminate large exports; the silence covers set_time_limit being disabled in php.ini.
 				@set_time_limit( 0 );
 				if ( connection_aborted() ) {
 					exit;

--- a/live-sandbox-editor/templates/sandbox-view.php
+++ b/live-sandbox-editor/templates/sandbox-view.php
@@ -14,7 +14,7 @@ namespace Live_Sandbox_Editor;
 
 \defined( 'ABSPATH' ) || exit;
 
-$theme_options = array(
+$live_sandbox_editor_theme_options = array(
 	array(
 		'value'    => 'system',
 		'label'    => __( 'System', 'live-sandbox-editor' ),
@@ -32,7 +32,7 @@ $theme_options = array(
 	),
 );
 
-$quick_links = array(
+$live_sandbox_editor_quick_links = array(
 	array(
 		'label' => __( 'Homepage', 'live-sandbox-editor' ),
 		'path'  => '/',
@@ -105,7 +105,7 @@ $quick_links = array(
 					hidden
 					data-wp-bind--hidden="!state.urlMenuOpen"
 				>
-					<?php foreach ( $quick_links as $link ) : ?>
+					<?php foreach ( $live_sandbox_editor_quick_links as $link ) : ?>
 						<button
 							type="button"
 							role="menuitem"
@@ -138,16 +138,16 @@ $quick_links = array(
 						role="radiogroup"
 						aria-label="<?php esc_attr_e( 'Editor theme', 'live-sandbox-editor' ); ?>"
 					>
-						<?php foreach ( $theme_options as $option ) : ?>
+						<?php foreach ( $live_sandbox_editor_theme_options as $live_sandbox_editor_option ) : ?>
 							<button
 								type="button"
 								role="radio"
 								class="lse-theme-toggle-option"
-								data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'value' => $option['value'] ) ) ); ?>"
+								data-wp-context="<?php echo esc_attr( wp_json_encode( array( 'value' => $live_sandbox_editor_option['value'] ) ) ); ?>"
 								data-wp-on--click="actions.setThemeMode"
-								data-wp-bind--aria-checked="<?php echo esc_attr( $option['is_state'] ); ?>"
-								data-wp-class--is-active="<?php echo esc_attr( $option['is_state'] ); ?>"
-							><?php echo esc_html( $option['label'] ); ?></button>
+								data-wp-bind--aria-checked="<?php echo esc_attr( $live_sandbox_editor_option['is_state'] ); ?>"
+								data-wp-class--is-active="<?php echo esc_attr( $live_sandbox_editor_option['is_state'] ); ?>"
+							><?php echo esc_html( $live_sandbox_editor_option['label'] ); ?></button>
 						<?php endforeach; ?>
 					</div>
 				</div>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"build": "vite build",
 		"watch": "vite build --watch",
 		"zip": "npm run build && zip -r live-sandbox-editor.zip live-sandbox-editor",
-		"ci-check": "tsgo --noEmit && biome check . && npm run build && composer validate --strict && composer validate --strict --working-dir=live-sandbox-editor && find live-sandbox-editor src -path 'live-sandbox-editor/vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l && composer lint:src"
+		"check:plugin": "out=$(wp-env run cli wp plugin check live-sandbox-editor --require=./wp-content/plugins/plugin-check/cli.php 2>/dev/null); printf '%s\n' \"$out\"; ! printf '%s\n' \"$out\" | grep -qE '\tERROR\t'",
+		"ci-check": "tsgo --noEmit && biome check . && npm run build && composer validate --strict && composer validate --strict --working-dir=live-sandbox-editor && find live-sandbox-editor src -path 'live-sandbox-editor/vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l && composer lint:src && npm run check:plugin"
 	},
 	"author": "sirreal",
 	"license": "GPL-2.0",


### PR DESCRIPTION
Runs WordPress Plugin Check against the plugin in `npm run ci-check` (via wp-env locally) and in a new GitHub Actions job using `WordPress/plugin-check-action` with `strict: true`. `.wp-env.json` now bundles the plugin-check zip so the local cli container has it active after `wp-env start --update`.

The local script greps the default-table output for ERROR rows because `wp plugin check` exits 0 in all currently-released formats.