### PR TITLE
Add admin auth, toolbar specs, and tighten assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       # `install-deps` only installs apt packages (libnss3, libatk, …);
       # the browser binary is already on disk from postinstall.
       - name: Install Playwright system dependencies
-        run: npx --no-install playwright install-deps chromium
+        run: node_modules/.bin/playwright install-deps chromium
 
       - name: Build JS bundle
         run: npm run build
@@ -122,7 +122,7 @@ jobs:
       # an auto-port at config-load time, so no explicit start step is
       # needed. retries=1 is wired via the CI env var below.
       - name: Run Playwright tests
-        run: npx --no-install playwright test
+        run: node_modules/.bin/playwright test
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,13 +105,27 @@ jobs:
       - name: Install plugin Composer dependencies
         run: composer install --no-interaction --prefer-dist --no-progress --no-dev --working-dir=live-sandbox-editor
 
+      # Cache the Chromium binary in ~/.cache/ms-playwright keyed on the
+      # exact @playwright/test version from package-lock.json. Must run
+      # before `npm ci` so the postinstall step (`playwright install
+      # chromium`) is a no-op on cache hit.
+      - name: Read Playwright version
+        id: pw
+        run: echo "version=$(jq -r '.packages["node_modules/@playwright/test"].version' package-lock.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
       # `npm ci` runs `postinstall: playwright install chromium`, which
-      # downloads the browser binary into ~/.cache/ms-playwright.
+      # downloads the browser binary on cache miss and skips on hit.
       - name: Install Node dependencies
         run: npm ci
 
       # `install-deps` only installs apt packages (libnss3, libatk, …);
-      # the browser binary is already on disk from postinstall.
+      # the browser binary is already on disk from postinstall or cache.
       - name: Install Playwright system dependencies
         run: node_modules/.bin/playwright install-deps chromium
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,68 @@ jobs:
         with:
           build-dir: ./live-sandbox-editor
           strict: true
+
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+
+      # The plugin's runtime depends on wp-php-toolkit/reprint-exporter
+      # (see live-sandbox-editor/composer.json) for the sandbox sync
+      # flow. wp-env mounts ../live-sandbox-editor as a plugin, so its
+      # vendor/ must exist before the specs boot Playground.
+      - name: Install plugin Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress --no-dev --working-dir=live-sandbox-editor
+
+      # `npm ci` runs `postinstall: playwright install chromium`, which
+      # downloads the browser binary into ~/.cache/ms-playwright.
+      - name: Install Node dependencies
+        run: npm ci
+
+      # `install-deps` only installs apt packages (libnss3, libatk, …);
+      # the browser binary is already on disk from postinstall.
+      - name: Install Playwright system dependencies
+        run: npx --no-install playwright install-deps chromium
+
+      - name: Build JS bundle
+        run: npm run build
+
+      # `ensureWpEnvRunning()` in playwright.config.ts boots wp-env on
+      # an auto-port at config-load time, so no explicit start step is
+      # needed. retries=1 is wired via the CI env var below.
+      - name: Run Playwright tests
+        run: npx --no-install playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@
 
 # Used by agents during Playwright-driven debug sessions.
 .playwright-mcp
+
+# Playwright test artifacts.
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
+# Cached state for the test-dedicated wp-env session.
+/tests/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.14",
+				"@playwright/test": "^1.59.1",
 				"@tsconfig/strictest": "^2.0.5",
+				"@wordpress/env": "^11.5.0",
 				"@wordpress/interactivity": "^6.45.0",
 				"typescript": "npm:@typescript/native-preview@beta",
 				"vite": "^8.x"
@@ -217,6 +219,476 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@inquirer/ansi": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+			"integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+			"integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.21",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+			"integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+			"integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "4.2.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+			"integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/external-editor": "^1.0.3",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+			"integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+			"integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+			"integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+			"integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+			"integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^4.3.2",
+				"@inquirer/confirm": "^5.1.21",
+				"@inquirer/editor": "^4.2.23",
+				"@inquirer/expand": "^4.0.23",
+				"@inquirer/input": "^4.3.1",
+				"@inquirer/number": "^3.0.23",
+				"@inquirer/password": "^4.0.23",
+				"@inquirer/rawlist": "^4.1.11",
+				"@inquirer/search": "^3.2.2",
+				"@inquirer/select": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+			"integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+			"integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+			"integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^1.0.2",
+				"@inquirer/core": "^10.3.2",
+				"@inquirer/figures": "^1.0.15",
+				"@inquirer/type": "^3.0.10",
+				"yoctocolors-cjs": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+			"integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/file-exists/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@kwsites/file-exists/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -236,6 +708,579 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@octokit/app": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+			"integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-app": "^6.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/types": "^12.0.0",
+				"@octokit/webhooks": "^12.0.4"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+			"integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.3.1",
+				"lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+				"universal-github-app-jwt": "^1.1.2",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+			"integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"@types/btoa-lite": "^1.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+			"integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+			"integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+			"integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+			"integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.0.0",
+				"@octokit/auth-oauth-user": "^4.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/oauth-methods": "^4.0.0",
+				"@types/aws-lambda": "^8.10.83",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-authorization-url": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+			"integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+			"integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-graphql": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+			"integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+			"integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.2.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
+		"node_modules/@octokit/webhooks": {
+			"version": "12.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+			"integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/webhooks-methods": "^4.1.0",
+				"@octokit/webhooks-types": "7.6.1",
+				"aggregate-error": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+			"integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-types": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.127.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -244,6 +1289,307 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@php-wasm/cli-util": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.29.tgz",
+			"integrity": "sha512-saVEkjCQGsLBrg0MB6oHF5jZudLK0siKXiCMFkbe99DqRQSckE59PHWh7LJ2nrtTO7rayMqdMe09Pa+5EpSS6Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.29",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/logger": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.29.tgz",
+			"integrity": "sha512-UPm67EQYA4W487HsdSVBzU/QEieXw4MSGBXUmDepqGtn/CXq+1cbvfK/MfgbzDF/M/q7pg5qea0Eb11Guvs8Fg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.29.tgz",
+			"integrity": "sha512-qsjkAUAr9oUSnPtcILE5KZqQQBF62atEfSfkyqJb8Lf3RdIrorqnx4/GiBu8Qz+uDhQc4GvSUPg2en4wJ1PNpQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.29",
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/node-5-2": "3.1.29",
+				"@php-wasm/node-7-4": "3.1.29",
+				"@php-wasm/node-8-0": "3.1.29",
+				"@php-wasm/node-8-1": "3.1.29",
+				"@php-wasm/node-8-2": "3.1.29",
+				"@php-wasm/node-8-3": "3.1.29",
+				"@php-wasm/node-8-4": "3.1.29",
+				"@php-wasm/node-8-5": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-5-2": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.29.tgz",
+			"integrity": "sha512-6giRuYnQkGrpA20sqteq/lHlZrpBw46iIqxDN4+sV5sMODMdIpr6xzSRh3t80xjGGNOkHH4D+FxqwyCvM608Lw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.29.tgz",
+			"integrity": "sha512-Y17c4bbDyV7M8OkG/dJ7/y36fgHcE9xMXXGHVQRNpFJn0CIJP1unWJWBpkzLTZtliKJv1jvcfmUc+xkGSL1RdQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.29.tgz",
+			"integrity": "sha512-lzVN75ktC36hRqPkvJB6dXoE2h3PQ9hQGvYgus9p0uqEeUaPq7A7gYn6YSLu1iYBvoIvMxdTS7CzV/6e/PG5TQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.29.tgz",
+			"integrity": "sha512-ZFJzqcFYJ7KEDIj0LStvFri2yYQpxJ9xIBP7dYPP9h1lgVYybRnRFTp4TUwKb5j3FRkcSkSB0oZc0BVpT+8LRg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.29.tgz",
+			"integrity": "sha512-ly62jp97xjTDZYGzoEbJt1tEkZktrKd5RTy1B8awzgPepxb8+F0d7BaIGlIK4EnxI2S/mTw2m5sDhbzAibycqQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.29.tgz",
+			"integrity": "sha512-pKV0MoXNvXFEs5mZ/oCPUDNxCtSxIGjGov89fohyjCPUjTmBQUXkkDMsneCgipUubc/Ysbm/hVPWB+VuhWElPg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.29.tgz",
+			"integrity": "sha512-HXJ8GzqNaYPjN/V4RC77lCJUd7YYRlQtV7JTdKhRdq56e8CezbaFu25mUtpJGeXaJ0CNTu7e0SxQ6lGTq2spIg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.29.tgz",
+			"integrity": "sha512-5dQqlD4GgPzH8cAehShyU7+QgVr02ChvRIu1COhWhGDsv/a5tzAj8rXpnB79Xn6+BUeVAXJ4THx9kMttsuLjhA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.29.tgz",
+			"integrity": "sha512-I2Outwb6VzdzNLYzvr+3vrF7DnkbD+TNS9Hefo/3rcp8KWtaA8OBa+3SvZ6K/nTDAk3KphpHMlm2F4DQNkC+ug==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.29"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.29.tgz",
+			"integrity": "sha512-5+An/zjhjfKKFDNgzQracspFm5x0H/IZ/NWhte9+QbdSIkXPcFZN6ZpuxSRU0d5H3J8EwN52/QNcY/7+1IwZDw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.29.tgz",
+			"integrity": "sha512-oAgV8WkbWJ6j3ZhWoRjJivyuYdTKodtLjExEQ49VTGRVvyQgjNKz3CIO39Pnnt5KrYFmj1+YnEPjzNAfRMUjUQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.29"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.29.tgz",
+			"integrity": "sha512-RsvMUNh8YUE+ub5FjEYzK/NkUDe+qFDarhnHs+Xa6VISC6IT/zfbzzAouxq55zfTBBq3OoAAfNIr/5hvUL69BQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/progress": "3.1.29",
+				"@php-wasm/stream-compression": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.29.tgz",
+			"integrity": "sha512-k7ZIbibADTK0B/hsgFZ4RDPnIKZ1p37c2qAjZts9nl5C4zCzGO9giLA16wBV/+78vL8hkLkNQSQpkQlBZVxn3g==",
+			"dev": true,
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.29.tgz",
+			"integrity": "sha512-cHwCofTpLNKt8VedLFOj6F+icRPoEzmHSzcK/lUpoiyfRjTTAgrb5vh+3HGG+JH4kYMUsrVoYUrOrsgBey2p8w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.29",
+				"@php-wasm/universal": "3.1.29"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.29.tgz",
+			"integrity": "sha512-+mNZAunAPuV2WAjexp+e6HxLQxcphJZ6ent767CuIrj466gzvhYLrYVZwgIUJxR66QCrvfX2wIpEKMbvS0ElGg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"ws": "8.18.0",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"xdebug-bridge": "xdebug-bridge.js"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@preact/signals": {
@@ -538,6 +1884,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@simple-git/args-pathspec": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+			"integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@simple-git/argv-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+			"integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-git/args-pathspec": "^1.0.3"
+			}
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@tsconfig/strictest": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.8.tgz",
@@ -554,6 +1943,88 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/aws-lambda": {
+			"version": "8.10.161",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+			"integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/btoa-lite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+			"integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+			"integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -661,6 +2132,35 @@
 				"win32"
 			]
 		},
+		"node_modules/@wordpress/env": {
+			"version": "11.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.5.0.tgz",
+			"integrity": "sha512-JWtSqja0yGa5F2LM5OwFnc0d1nXRXQt6TdGne+jBU5gcRfxj4+c/Sn+fheBFDBU0xLkTsefeJqJSafQZ66F1UA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@inquirer/prompts": "^7.2.0",
+				"@wp-playground/cli": "^3.0.48",
+				"chalk": "^4.0.0",
+				"copy-dir": "^1.3.0",
+				"cross-spawn": "^7.0.6",
+				"docker-compose": "^0.24.3",
+				"extract-zip": "^1.6.7",
+				"got": "^11.8.5",
+				"js-yaml": "^3.13.1",
+				"ora": "^4.0.2",
+				"rimraf": "^5.0.10",
+				"simple-git": "^3.5.0",
+				"yargs": "^17.3.0"
+			},
+			"bin": {
+				"wp-env": "bin/wp-env"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/interactivity": {
 			"version": "6.45.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.45.0.tgz",
@@ -676,6 +2176,57 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wp-playground/blueprints": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.29.tgz",
+			"integrity": "sha512-ueVyFznR5fvzKxHpve1MZX8FA6SOJQqnrf/5N+tqJ48D5SBUd0OR+clwrKO2duJlnouC1I0JX8z8TQCbooY2SQ==",
+			"dev": true,
+			"dependencies": {
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/progress": "3.1.29",
+				"@php-wasm/stream-compression": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"@php-wasm/web-service-worker": "3.1.29",
+				"@wp-playground/common": "3.1.29",
+				"@wp-playground/storage": "3.1.29",
+				"@wp-playground/wordpress": "3.1.29",
+				"ajv": "8.12.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.29.tgz",
+			"integrity": "sha512-VLtuCV7BkB54nZJjbuBJrOAfoc9/F27+imVym7DoIuKb4xv3i+7tMAVEOQUTsz3c13uHzp9xtO5lwV9T1AvS9g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.29",
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/node": "3.1.29",
+				"@php-wasm/progress": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"@php-wasm/xdebug-bridge": "3.1.29",
+				"@wp-playground/blueprints": "3.1.29",
+				"@wp-playground/common": "3.1.29",
+				"@wp-playground/storage": "3.1.29",
+				"@wp-playground/tools": "3.1.29",
+				"@wp-playground/wordpress": "3.1.29",
+				"express": "4.22.0",
+				"fs-extra": "11.1.1",
+				"tmp-promise": "3.0.3",
+				"wasm-feature-detect": "1.8.0",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"wp-playground-cli": "wp-playground.js"
+			}
+		},
 		"node_modules/@wp-playground/client": {
 			"version": "3.1.27",
 			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-3.1.27.tgz",
@@ -684,6 +2235,836 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/common": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.29.tgz",
+			"integrity": "sha512-tmzhEFaUaftl1Ml0jHESR1TxCGnbl1ab02LJn6RkxOVp3mmg90fyM//Y1oW6zXP8nwx052rj2G9QkkzhtO/Xbg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/storage": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.29.tgz",
+			"integrity": "sha512-Xlpi8J+12Bv2TJeipbMCdf2uuYOiXVhqhM6ID4dJoh1FlFjXTtmSEqH9kel5RuPoy9W1oiTXHO5I1cZRWqZUJQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"@zip.js/zip.js": "2.7.57",
+				"isomorphic-git": "1.37.6",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10"
+			}
+		},
+		"node_modules/@wp-playground/tools": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.29.tgz",
+			"integrity": "sha512-Qb7Lf6c053rms+gEyb1/p+8FKpn8LXGys5Ef+Ty74lPe2sfnH8FoS+ux7M2Rqn+9R+IrOxuV8F66UEP+yYHyLg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wp-playground/blueprints": "3.1.29"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/wordpress": {
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.29.tgz",
+			"integrity": "sha512-JZ7WAEJjphSlZbjKgQzaiRKg/1cacoTv5GGZi1ocXIjShGRea9kidPnxtMIJBJRcJzN8pqKxu6EVc9X8UDReBQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.29",
+				"@php-wasm/universal": "3.1.29",
+				"@php-wasm/util": "3.1.29",
+				"@wp-playground/common": "3.1.29"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.7.57",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+			"integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=16.5.0"
+			}
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/body-parser": {
+			"version": "1.20.5",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+			"integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"content-type": "~1.0.5",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.15.1",
+				"raw-body": "~2.5.3",
+				"type-is": "~1.6.18",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/body-parser/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chardet": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"engines": [
+				"node >= 0.8"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/copy-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -696,6 +3077,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/docker-compose": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+			"integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/dompurify": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
@@ -703,6 +3104,295 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/extract-zip": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"concat-stream": "^1.6.2",
+				"debug": "^2.6.9",
+				"mkdirp": "^0.5.4",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/fdir": {
@@ -723,6 +3413,107 @@
 				}
 			}
 		},
+		"node_modules/finalhandler": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+			"integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "~2.0.2",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fs-ext-extra-prebuilt": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+			"integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"nan": "^2.24.0"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -736,6 +3527,584 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/isomorphic-git": {
+			"version": "1.37.6",
+			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.6.tgz",
+			"integrity": "sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"minimisted": "^2.0.0",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^4.0.0",
+				"sha.js": "^2.4.12",
+				"simple-get": "^4.0.1"
+			},
+			"bin": {
+				"isogit": "cli.cjs"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -999,6 +4368,157 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-symbols": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^2.4.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/log-symbols/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-symbols/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/log-symbols/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lru-cache": {
+			"name": "@wolfy1339/lru-cache",
+			"version": "11.0.2-patch.1",
+			"resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+			"integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "18 >=18.20 || 20 || >=22"
+			}
+		},
 		"node_modules/marked": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -1011,6 +4531,161 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
 		"node_modules/monaco-editor": {
 			"version": "0.55.1",
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -1020,6 +4695,30 @@
 				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/nan": {
+			"version": "2.26.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1040,6 +4739,245 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/octokit": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+			"integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/app": "^14.0.2",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-graphql": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+				"@octokit/plugin-retry": "^6.0.0",
+				"@octokit/plugin-throttling": "^8.0.0",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.2.0",
+				"is-interactive": "^1.0.0",
+				"log-symbols": "^3.0.0",
+				"mute-stream": "0.0.8",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ora/node_modules/mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/path-to-regexp": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1058,6 +4996,73 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/postcss": {
@@ -1100,6 +5105,226 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/raw-body/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/restore-cursor/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.17",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -1134,6 +5359,353 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/send": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "~2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "~2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/send/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/serve-static": {
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "~0.19.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"dev": true,
+			"license": "(MIT AND BSD-3-Clause)",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/simple-git": {
+			"version": "3.36.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+			"integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"@simple-git/args-pathspec": "^1.0.3",
+				"@simple-git/argv-parser": "^1.1.0",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
+		},
+		"node_modules/simple-git/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/simple-git/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1142,6 +5714,163 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tinyglobby": {
@@ -1161,6 +5890,58 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tmp": "^0.2.0"
+			}
+		},
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/to-buffer/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1168,6 +5949,42 @@
 			"dev": true,
 			"license": "0BSD",
 			"optional": true
+		},
+		"node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/typescript": {
 			"name": "@typescript/native-preview",
@@ -1187,6 +6004,88 @@
 				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
 				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
 				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/universal-github-app-jwt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+			"integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonwebtoken": "^9.0.0",
+				"jsonwebtoken": "^9.0.2"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vite": {
@@ -1265,6 +6164,309 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+			"integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -5,12 +5,25 @@
 	"description": "",
 	"private": true,
 	"scripts": {
+		"postinstall": "playwright install chromium",
 		"dev": "vite",
 		"build": "vite build",
 		"watch": "vite build --watch",
 		"zip": "npm run build && zip -r live-sandbox-editor.zip live-sandbox-editor",
+		"wp-env": "wp-env",
+		"wp-env:start": "wp-env start",
+		"wp-env:stop": "wp-env stop",
+		"test:wp-env:stop": "cd tests && wp-env stop && rm -rf .cache",
+		"test:wp-env:destroy": "cd tests && wp-env destroy && rm -rf .cache",
+		"typecheck": "tsgo --noEmit",
+		"lint:js": "biome check .",
+		"lint:php": "find live-sandbox-editor src -path 'live-sandbox-editor/vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l",
+		"lint:phpcs": "composer lint:src",
+		"validate:composer": "composer validate --strict && composer validate --strict --working-dir=live-sandbox-editor",
 		"check:plugin": "out=$(wp-env run cli wp plugin check live-sandbox-editor --require=./wp-content/plugins/plugin-check/cli.php 2>/dev/null); printf '%s\n' \"$out\"; ! printf '%s\n' \"$out\" | grep -qE '\tERROR\t'",
-		"ci-check": "tsgo --noEmit && biome check . && npm run build && composer validate --strict && composer validate --strict --working-dir=live-sandbox-editor && find live-sandbox-editor src -path 'live-sandbox-editor/vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l && composer lint:src && npm run check:plugin"
+		"test:pw": "npm run build && playwright test",
+		"test:pw:ui": "npm run build && playwright test --ui",
+		"ci-check": "npm run typecheck && npm run lint:js && npm run build && npm run validate:composer && npm run lint:php && npm run lint:phpcs && npm run check:plugin && npm run test:pw"
 	},
 	"author": "sirreal",
 	"license": "GPL-2.0",
@@ -20,7 +33,9 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.14",
+		"@playwright/test": "^1.59.1",
 		"@tsconfig/strictest": "^2.0.5",
+		"@wordpress/env": "^11.5.0",
 		"@wordpress/interactivity": "^6.45.0",
 		"typescript": "npm:@typescript/native-preview@beta",
 		"vite": "^8.x"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,9 +53,23 @@ export default defineConfig({
 			timeout: 10 * 60 * 1000,
 		},
 		{
-			name: 'chromium',
+			// Logs into wp-admin once and writes the cookie/localStorage
+			// state to `tests/.cache/admin-storage.json`. The chromium
+			// project below loads that file via `use.storageState` so each
+			// spec opens already-authenticated — no per-test wp-login.php
+			// round trip.
+			name: 'auth',
+			testDir: './tests/e2e',
+			testMatch: /auth\.setup\.ts/,
 			dependencies: ['wp-env'],
-			use: { ...devices['Desktop Chrome'] },
+		},
+		{
+			name: 'chromium',
+			dependencies: ['auth'],
+			use: {
+				...devices['Desktop Chrome'],
+				storageState: 'tests/.cache/admin-storage.json',
+			},
 		},
 	],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,61 @@
+import { defineConfig, devices } from '@playwright/test';
+import { ensureWpEnvRunning } from './tests/e2e/helpers/wp-env.js';
+
+// Resolved at config-load time. `ensureWpEnvRunning` is sync (it spawns
+// wp-env or pings the cached port via a child process) so the baseURL
+// below can use it directly. On warm runs this is a single sub-process
+// ping to the cached port — no wp-env restart.
+const session = ensureWpEnvRunning();
+const BASE_URL = process.env['WP_BASE_URL'] ?? session.baseUrl;
+
+// `CI=true` is set by every mainstream CI runner — GitHub Actions,
+// GitLab CI, CircleCI, etc. — and is the customary gate for
+// "behave-like-CI" branches in npm tooling. The strict-equality check
+// avoids tripping on stray empty values.
+const IS_CI = process.env['CI'] === 'true';
+
+export default defineConfig({
+	testDir: './tests/e2e',
+	// Playground boots an iframe against playground.wordpress.net — keep these
+	// generous; a cold boot can run 60+ seconds before the sandbox is "Ready".
+	timeout: 5 * 60 * 1000,
+	expect: { timeout: 90 * 1000 },
+	// Specs are independent: each test owns its browser context and
+	// boots its own Playground remote session, and the only host-side
+	// write (fixtures) happens in the wp-env setup project before any
+	// chromium spec runs. Resource pressure on PHP-FPM / bandwidth /
+	// remote Playground may surface as flake under high parallelism —
+	// drop `workers` if that lands.
+	fullyParallel: true,
+	// CI gets one retry to absorb network-induced flake from
+	// playground.wordpress.net cold boots; local runs stay at 0 so a
+	// real failure surfaces on the first attempt instead of being
+	// silently retried.
+	retries: IS_CI ? 1 : 0,
+	reporter: IS_CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+	use: {
+		baseURL: BASE_URL,
+		actionTimeout: 30 * 1000,
+		navigationTimeout: 60 * 1000,
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'retain-on-failure',
+	},
+	projects: [
+		{
+			// The "wp-env" project only primes test fixtures now. Actually
+			// booting wp-env happens at config-load time via
+			// `ensureWpEnvRunning()` so the URL is available before any
+			// project runs.
+			name: 'wp-env',
+			testDir: './tests/e2e',
+			testMatch: /wp-env\.setup\.ts/,
+			timeout: 10 * 60 * 1000,
+		},
+		{
+			name: 'chromium',
+			dependencies: ['wp-env'],
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+});

--- a/tests/.wp-env.json
+++ b/tests/.wp-env.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"SCRIPT_DEBUG": true,
+		"WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
+	},
+	"plugins": ["../live-sandbox-editor"],
+	"mappings": {
+		"wp-content/mu-plugins/lse-tests-no-pointers.php": "./mu-plugins/disable-admin-pointers.php"
+	},
+	"testsEnvironment": false
+}

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,0 +1,16 @@
+/**
+ * Playwright "setup project" that logs into wp-admin once and persists
+ * the resulting browser state (cookies + localStorage) to disk. The
+ * chromium project consumes that file via `use.storageState`, so every
+ * spec opens already-authenticated — no per-test `loginAsAdmin` round
+ * trip. The wp-env setup project runs first (dependency chain in
+ * playwright.config.ts) so wp-login.php is reachable by the time we
+ * fill the form.
+ */
+import { test as setup } from '@playwright/test';
+import { loginAsAdmin, ADMIN_STORAGE_STATE } from './helpers/wp-admin.js';
+
+setup('authenticate as admin', async ({ page }) => {
+	await loginAsAdmin(page);
+	await page.context().storageState({ path: ADMIN_STORAGE_STATE });
+});

--- a/tests/e2e/helpers/sandbox.ts
+++ b/tests/e2e/helpers/sandbox.ts
@@ -1,0 +1,23 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+const READY_TIMEOUT = 4 * 60 * 1000;
+
+/**
+ * Wait until the sandbox status bar reports "Ready" and the loading overlay
+ * has been hidden. Both signals are produced by `src/store.ts` once Playground
+ * boots and the post-import fixups run.
+ */
+export async function waitForSandboxReady(page: Page, timeout = READY_TIMEOUT): Promise<void> {
+	await expect(page.locator('#live-sandbox-editor-root')).toBeVisible({ timeout: 30 * 1000 });
+	await expect(page.locator('#lse-loading')).toHaveClass(/(^|\s)hidden(\s|$)/, { timeout });
+	await expect(statusText(page)).toHaveText('Ready', { timeout });
+}
+
+export function statusText(page: Page): Locator {
+	return page.locator('.lse-status-indicator span').last();
+}
+
+export function urlInput(page: Page): Locator {
+	return page.locator('.lse-url-input');
+}

--- a/tests/e2e/helpers/sandbox.ts
+++ b/tests/e2e/helpers/sandbox.ts
@@ -4,14 +4,22 @@ import { expect } from '@playwright/test';
 const READY_TIMEOUT = 4 * 60 * 1000;
 
 /**
- * Wait until the sandbox status bar reports "Ready" and the loading overlay
- * has been hidden. Both signals are produced by `src/store.ts` once Playground
- * boots and the post-import fixups run.
+ * Wait until the sandbox has finished booting Playground and applying
+ * the post-import fixups.
+ *
+ * Signals chosen are DOM-state, sticky derivatives of `state.isReady`:
+ * the loading overlay's `data-wp-class--hidden="state.isReady"` flips on
+ * once and never reverts, and the URL input's
+ * `data-wp-bind--disabled="state.notReady"` enables once and stays
+ * enabled. Status text is intentionally NOT asserted here — the
+ * test-upgrade flow in src/store.ts overwrites "Ready" with
+ * "Preparing upgrade test…" on the next microtask, so a
+ * `toHaveText('Ready')` poll races and frequently misses.
  */
 export async function waitForSandboxReady(page: Page, timeout = READY_TIMEOUT): Promise<void> {
 	await expect(page.locator('#live-sandbox-editor-root')).toBeVisible({ timeout: 30 * 1000 });
 	await expect(page.locator('#lse-loading')).toHaveClass(/(^|\s)hidden(\s|$)/, { timeout });
-	await expect(statusText(page)).toHaveText('Ready', { timeout });
+	await expect(urlInput(page)).toBeEnabled({ timeout });
 }
 
 export function statusText(page: Page): Locator {

--- a/tests/e2e/helpers/wp-admin.ts
+++ b/tests/e2e/helpers/wp-admin.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+const USERNAME = process.env['WP_ADMIN_USER'] ?? 'admin';
+const PASSWORD = process.env['WP_ADMIN_PASSWORD'] ?? 'password';
+
+/**
+ * Log into wp-admin. wp-env's default credentials are admin/password.
+ * Idempotent: returns immediately if a logged-in cookie is already
+ * present. Admin "welcome" pointers that would otherwise overlay
+ * plugins.php / themes.php row actions are suppressed server-side by
+ * the lse-tests-no-pointers mu-plugin (mapped via tests/.wp-env.json).
+ */
+export async function loginAsAdmin(page: Page): Promise<void> {
+	await page.goto('/wp-login.php');
+	if (page.url().includes('/wp-admin/')) {
+		return;
+	}
+	await page.locator('input[name="log"]').fill(USERNAME);
+	await page.locator('input[name="pwd"]').fill(PASSWORD);
+	await Promise.all([page.waitForURL(/\/wp-admin\//), page.locator('input[name="wp-submit"]').click()]);
+	await expect(page.locator('body')).toContainText('Dashboard');
+}
+
+export function setupPageUrl(): string {
+	return '/wp-admin/admin.php?page=live-sandbox-editor-setup';
+}
+
+export function runPageUrl(manifestParam?: string): string {
+	const base = '/wp-admin/admin.php?page=live-sandbox-editor';
+	return manifestParam ? `${base}&manifest=${encodeURIComponent(manifestParam)}` : base;
+}

--- a/tests/e2e/helpers/wp-admin.ts
+++ b/tests/e2e/helpers/wp-admin.ts
@@ -4,6 +4,11 @@ import { expect } from '@playwright/test';
 const USERNAME = process.env['WP_ADMIN_USER'] ?? 'admin';
 const PASSWORD = process.env['WP_ADMIN_PASSWORD'] ?? 'password';
 
+// Storage state captured once by the `auth` setup project and reused
+// via `use.storageState` in playwright.config.ts. Lives under the
+// gitignored tests/.cache/ tree alongside the wp-env port cache.
+export const ADMIN_STORAGE_STATE = 'tests/.cache/admin-storage.json';
+
 /**
  * Log into wp-admin. wp-env's default credentials are admin/password.
  * Idempotent: returns immediately if a logged-in cookie is already

--- a/tests/e2e/helpers/wp-cli.ts
+++ b/tests/e2e/helpers/wp-cli.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from 'node:child_process';
+import { TESTS_CWD } from './wp-env.js';
+
+/**
+ * Run a WP-CLI command inside the test wp-env container and return
+ * stdout. Throws if the command exits non-zero unless `ignoreErrors` is
+ * set.
+ *
+ * `cwd: TESTS_CWD` is what binds this to the tests/.wp-env.json session
+ * instead of the project root's developer-facing config — wp-env picks
+ * its environment based on the location of the .wp-env.json it finds.
+ * `npx --no-install` keeps the lookup inside the project's
+ * node_modules so we don't accidentally hit a global wp-env install
+ * with a different version.
+ */
+export function wpCli(args: string[], opts: { ignoreErrors?: boolean } = {}): string {
+	try {
+		return execFileSync('npx', ['--no-install', 'wp-env', 'run', 'cli', '--', 'wp', ...args], {
+			cwd: TESTS_CWD,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		}).trim();
+	} catch (err) {
+		if (opts.ignoreErrors) {
+			return '';
+		}
+		throw err;
+	}
+}
+
+export function getInstalledPluginVersion(entry: string): string {
+	const slug = entry.split('/')[0] ?? entry;
+	return wpCli(['plugin', 'get', slug, '--field=version']);
+}
+
+export function getInstalledThemeVersion(stylesheet: string): string {
+	return wpCli(['theme', 'get', stylesheet, '--field=version']);
+}

--- a/tests/e2e/helpers/wp-env.ts
+++ b/tests/e2e/helpers/wp-env.ts
@@ -1,0 +1,266 @@
+/**
+ * Manage the lifecycle of the wp-env session dedicated to Playwright runs.
+ *
+ * Why a dedicated session: the project root's `.wp-env.json` is what the
+ * developer uses for manual exploration, typically pinned to port 8888.
+ * Running tests against that same session would either collide on the
+ * port or smash the developer's working state with the test fixtures.
+ * `tests/.wp-env.json` is a sibling config that wp-env hashes under a
+ * different installation dir, so both can be up at the same time.
+ *
+ * The port is picked by `wp-env start --auto-port` (wp-env walks
+ * upward from the configured port until it finds a free one) and
+ * cached in `tests/.cache/wp-env.json`. Subsequent runs read the
+ * cached port, ping it, and skip the `wp-env start` invocation
+ * entirely if the containers are still alive — the steady state
+ * during a tight test/edit loop.
+ *
+ * Concurrency: a sibling lock file (`tests/.cache/wp-env.json.lock`)
+ * serialises the read→start→write path so two parallel invocations
+ * can't both decide the cache is stale and race `wp-env start
+ * --auto-port` against each other. The fast warm-cache path stays
+ * outside the lock — only the slow start path takes it.
+ */
+import { spawnSync } from 'node:child_process';
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+	writeSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+// Playwright runs npm scripts from the project root, so `tests/` is at a
+// stable location relative to cwd. Avoid `import.meta.url` — Playwright's
+// TS transform loads helpers as CJS, where it isn't defined.
+export const TESTS_CWD = join(process.cwd(), 'tests');
+const CACHE_DIR = join(TESTS_CWD, '.cache');
+const CACHE_FILE = join(CACHE_DIR, 'wp-env.json');
+const LOCK_FILE = `${CACHE_FILE}.lock`;
+
+// wp-env's first-run cold pull can run ~2 minutes; the lock holder is
+// inside that span for the entire duration. Budget generously so a
+// legitimately busy session doesn't trip the timeout.
+const LOCK_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+const LOCK_POLL_INTERVAL_MS = 250;
+
+export interface WpEnvSession {
+	port: number;
+	baseUrl: string;
+}
+
+function readCache(): WpEnvSession | null {
+	// No `existsSync` pre-check: it would add a TOCTOU window where
+	// another process could delete the file between the check and the
+	// read. `readFileSync` already throws `ENOENT` on a missing file,
+	// which the catch below treats as a miss.
+	try {
+		const data = JSON.parse(readFileSync(CACHE_FILE, 'utf8')) as Partial<WpEnvSession>;
+		if (typeof data.port === 'number' && typeof data.baseUrl === 'string') {
+			return { port: data.port, baseUrl: data.baseUrl };
+		}
+	} catch {
+		// ENOENT (no cache yet) and JSON syntax errors are both treated
+		// as a miss; `startFreshSession()` rewrites the file under the
+		// lock.
+	}
+	return null;
+}
+
+function writeCache(session: WpEnvSession): void {
+	mkdirSync(CACHE_DIR, { recursive: true });
+	// Atomic write: writeFileSync truncates first, so a reader hitting
+	// the gap would see an empty file and parse-fail. `renameSync` is
+	// atomic on POSIX, so any reader sees either the old contents or
+	// the new — never a half-written intermediate.
+	const tmp = `${CACHE_FILE}.${process.pid}.tmp`;
+	writeFileSync(tmp, `${JSON.stringify(session, null, '\t')}\n`, 'utf8');
+	renameSync(tmp, CACHE_FILE);
+}
+
+/**
+ * Probe the cached port synchronously via a one-shot Node HTTP request
+ * embedded in a child process. Using a sub-process keeps this callable
+ * from `playwright.config.ts` (which runs synchronously at module load).
+ * `curl` would be simpler but is not guaranteed on every CI image —
+ * Node is.
+ */
+function pingPort(port: number): boolean {
+	const probe = `
+const http = require('http');
+const req = http.get(
+	{ host: '127.0.0.1', port: ${port}, path: '/wp-login.php', timeout: 3000 },
+	(res) => { res.resume(); process.exit(res.statusCode === 200 ? 0 : 1); },
+);
+req.on('error', () => process.exit(1));
+req.on('timeout', () => { req.destroy(); process.exit(1); });
+`;
+	const result = spawnSync(process.execPath, ['-e', probe], { stdio: 'ignore' });
+	return result.status === 0;
+}
+
+/**
+ * Block the current thread for `ms` milliseconds without spawning a
+ * child process. `Atomics.wait` returns "timed-out" because the
+ * SharedArrayBuffer is zero-initialised and we wait for "value 0
+ * differs from current"; the condition never holds, so the call
+ * sleeps for the full duration.
+ */
+function sleepSync(ms: number): void {
+	const buf = new Int32Array(new SharedArrayBuffer(4));
+	Atomics.wait(buf, 0, 0, ms);
+}
+
+/**
+ * Probe a PID for liveness. `process.kill(pid, 0)` doesn't actually
+ * deliver a signal — it only runs the kernel's permission/existence
+ * check.
+ *
+ * - `ESRCH`: no such process — dead. Lock is reclaimable.
+ * - `EPERM`: process exists but we can't signal it (different uid,
+ *   container boundary). Treat as alive — better to wait than to
+ *   bulldoze a healthy holder.
+ * - Anything else: be conservative and treat as alive.
+ */
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === 'EPERM';
+	}
+}
+
+function readLockHolderPid(): number | null {
+	try {
+		const pid = Number(readFileSync(LOCK_FILE, 'utf8').trim());
+		return Number.isFinite(pid) && pid > 0 ? pid : null;
+	} catch {
+		// The lock file may have been released between our open attempt
+		// and this read; the caller's retry loop handles that.
+		return null;
+	}
+}
+
+function acquireLock(): void {
+	mkdirSync(CACHE_DIR, { recursive: true });
+	const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+	while (true) {
+		try {
+			// `wx` = O_CREAT | O_EXCL. The kernel guarantees only one
+			// caller's open succeeds across processes — this is the
+			// actual atomic primitive the lock rides on.
+			const fd = openSync(LOCK_FILE, 'wx');
+			try {
+				writeSync(fd, String(process.pid));
+			} finally {
+				closeSync(fd);
+			}
+			return;
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code !== 'EEXIST') throw err;
+
+			// Lock is held. Check for a stale holder (process died
+			// without releasing) before we resign to waiting.
+			const holderPid = readLockHolderPid();
+			if (holderPid !== null && !isProcessAlive(holderPid)) {
+				// Stale: force-claim. The unlink may race with another
+				// contender's unlink, which is fine — at worst the
+				// next openSync attempt fails and we loop again.
+				try {
+					unlinkSync(LOCK_FILE);
+				} catch {
+					// Another contender beat us to the cleanup.
+				}
+				continue;
+			}
+
+			if (Date.now() > deadline) {
+				throw new Error(
+					`Timed out after ${LOCK_WAIT_TIMEOUT_MS}ms waiting for wp-env cache lock at ${LOCK_FILE} ` +
+						`(held by PID ${holderPid ?? 'unknown'}). Delete the file manually if the holder is gone.`,
+				);
+			}
+			sleepSync(LOCK_POLL_INTERVAL_MS);
+		}
+	}
+}
+
+function releaseLock(): void {
+	try {
+		unlinkSync(LOCK_FILE);
+	} catch {
+		// Idempotent — already gone (someone reclaimed it as stale, or
+		// we never actually acquired). Either way, nothing to do.
+	}
+}
+
+function withLock<T>(fn: () => T): T {
+	acquireLock();
+	try {
+		return fn();
+	} finally {
+		releaseLock();
+	}
+}
+
+function startFreshSession(): WpEnvSession {
+	// wp-env writes progress (Docker pulls, container status, the
+	// summary "started at" line) to stderr; stdout stays mostly empty.
+	// Capture both so the regex below can scan whichever stream the
+	// URL ends up on, and re-echo to the user's terminal so cold-pull
+	// progress isn't hidden.
+	const result = spawnSync('npx', ['--no-install', 'wp-env', 'start', '--auto-port'], {
+		cwd: TESTS_CWD,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	const stdout = result.stdout ?? '';
+	const stderr = result.stderr ?? '';
+	process.stdout.write(stdout);
+	process.stderr.write(stderr);
+	if (result.status !== 0) {
+		throw new Error(`wp-env start --auto-port exited with status ${result.status}.`);
+	}
+	const combined = `${stdout}\n${stderr}`;
+	const match = combined.match(/development\s+site[^\n]*?http:\/\/[^\s:]+:(\d+)/i);
+	if (!match?.[1]) {
+		throw new Error(
+			'wp-env start did not include a "development site started at http://…:<port>" line. ' +
+				'Either the wp-env output format changed or the dev environment is disabled in tests/.wp-env.json.',
+		);
+	}
+	const port = Number(match[1]);
+	return { port, baseUrl: `http://localhost:${port}` };
+}
+
+/**
+ * Return a live test wp-env session, starting one if necessary. Safe to
+ * call from synchronous contexts (e.g. `playwright.config.ts` load).
+ *
+ * Fast path (cache warm): a single ping outside the lock — no
+ * serialisation overhead in the common case where the containers are
+ * already up. Slow path (cache miss or stale): take the lock,
+ * **re-check inside the critical section**, and only then spawn
+ * `wp-env start`. The re-check is the load-bearing line: it ensures a
+ * contender that lost the race for the lock will see the winner's
+ * freshly written cache instead of redundantly starting a second
+ * session.
+ */
+export function ensureWpEnvRunning(): WpEnvSession {
+	const warm = readCache();
+	if (warm && pingPort(warm.port)) return warm;
+
+	return withLock(() => {
+		const recheck = readCache();
+		if (recheck && pingPort(recheck.port)) return recheck;
+		const session = startFreshSession();
+		writeCache(session);
+		return session;
+	});
+}

--- a/tests/e2e/specs/direct-run.spec.ts
+++ b/tests/e2e/specs/direct-run.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { loginAsAdmin, runPageUrl } from '../helpers/wp-admin.js';
+import { runPageUrl } from '../helpers/wp-admin.js';
 import { statusText, urlInput, waitForSandboxReady } from '../helpers/sandbox.js';
 
 test.describe('Direct Run', () => {
 	test('boots the sandbox when navigating straight to the Run page', async ({ page }) => {
-		await loginAsAdmin(page);
 		await page.goto(runPageUrl());
 
 		await waitForSandboxReady(page);

--- a/tests/e2e/specs/direct-run.spec.ts
+++ b/tests/e2e/specs/direct-run.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin, runPageUrl } from '../helpers/wp-admin.js';
+import { statusText, urlInput, waitForSandboxReady } from '../helpers/sandbox.js';
+
+test.describe('Direct Run', () => {
+	test('boots the sandbox when navigating straight to the Run page', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(runPageUrl());
+
+		await waitForSandboxReady(page);
+
+		await expect(statusText(page)).toHaveText('Ready');
+		await expect(urlInput(page)).toBeEnabled();
+		await expect(page.locator('#lse-preview-iframe')).toBeVisible();
+
+		// Editor toggle should be reachable once the sandbox is ready.
+		const editorToggle = page.locator('[data-wp-on--click="actions.toggleEditor"]');
+		await expect(editorToggle).toBeEnabled();
+	});
+});

--- a/tests/e2e/specs/plugin-update.spec.ts
+++ b/tests/e2e/specs/plugin-update.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { getInstalledPluginVersion } from '../helpers/wp-cli.js';
+import { loginAsAdmin } from '../helpers/wp-admin.js';
+import { statusText, waitForSandboxReady } from '../helpers/sandbox.js';
+
+const PERFORMANCE_LAB_ENTRY = 'performance-lab/load.php';
+
+// Failure-mode note for whoever lands here on a red CI:
+// This spec is a real-bug detector for the host→Playground upgrade
+// flow, not just a UI assertion. If `statusText` ends up containing
+// "Upgrade test failed: No upgrade link found on plugins.php…", the
+// sandbox booted and synced, but Playground's plugins.php didn't
+// render the upgrade row for the entry the test transferred. Causes
+// observed in practice:
+//   - `_site_transient_update_plugins` row not surviving the
+//     wp_options dump → import path (Reprint exporter / SQLite
+//     reimport stripping FROM_BASE64'd serialized data).
+//   - Playground re-running `wp_update_plugins()` on first admin
+//     render and overwriting the synced transient with its own
+//     (possibly empty) result.
+// Either is upstream of this test — investigate the plugin's sync
+// pipeline before relaxing the assertion.
+test.describe('Plugin update in sandbox', () => {
+	test('runs upgrade via in-row link, leaves host plugin untouched', async ({ page }) => {
+		const versionBefore = getInstalledPluginVersion(PERFORMANCE_LAB_ENTRY);
+
+		await loginAsAdmin(page);
+		await page.goto('/wp-admin/plugins.php');
+
+		// The host-side `in_plugin_update_message-<entry>` action appends the
+		// "test the plugin update in the sandbox" anchor inside the per-row
+		// update message. Match by the data attribute so the assertion fails
+		// loudly if the renderer drops the marker.
+		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${PERFORMANCE_LAB_ENTRY}"]`);
+		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
+		await upgradeLink.click();
+
+		// Run page should boot with testUpgrade in the URL.
+		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(PERFORMANCE_LAB_ENTRY);
+
+		// Wait until the sandbox is far enough along that the upgrade flow
+		// completed. `runTestUpgrade` sets either of these terminal statuses;
+		// poll for the upgrade-in-progress label which is the success signal.
+		await waitForSandboxReady(page).catch(() => {
+			// `runTestUpgrade` clobbers the "Ready" status with its own
+			// progress message, so a missed "Ready" isn't a failure. Fall
+			// through to the upgrade-state assertion below.
+		});
+		await expect(statusText(page)).toContainText(/Upgrade in progress|Upgrade test failed|Preparing upgrade test/i, {
+			timeout: 4 * 60 * 1000,
+		});
+		await expect(statusText(page)).not.toContainText(/failed/i);
+
+		const versionAfter = getInstalledPluginVersion(PERFORMANCE_LAB_ENTRY);
+		expect(versionAfter, 'host plugin version must not change').toBe(versionBefore);
+	});
+});

--- a/tests/e2e/specs/plugin-update.spec.ts
+++ b/tests/e2e/specs/plugin-update.spec.ts
@@ -31,7 +31,6 @@ test.describe('Plugin update in sandbox', () => {
 			/\/wp-admin\/update\.php\?action=upgrade-plugin&plugin=performance-lab%2Fload\.php&_wpnonce=[a-f0-9]+/;
 		await expect
 			.poll(() => page.frames().find((f) => upgradeUrlPattern.test(f.url()))?.url() ?? null, {
-				timeout: 5 * 1000,
 				message: 'Playground iframe should land on update.php?action=upgrade-plugin for this entry',
 			})
 			.toMatch(upgradeUrlPattern);
@@ -40,9 +39,7 @@ test.describe('Plugin update in sandbox', () => {
 		// by the "Go to Plugins page" link rendered after a successful
 		// update.php run.
 		const playgroundFrame = page.frameLocator('#lse-preview-iframe').frameLocator('iframe');
-		await expect(playgroundFrame.getByRole('link', { name: 'Go to Plugins page' })).toBeVisible({
-			timeout: 5 * 1000,
-		});
+		await expect(playgroundFrame.getByRole('link', { name: 'Go to Plugins page' })).toBeVisible();
 
 		const versionAfter = getInstalledPluginVersion(PERFORMANCE_LAB_ENTRY);
 		expect(versionAfter, 'host plugin version must not change').toBe(versionBefore);

--- a/tests/e2e/specs/plugin-update.spec.ts
+++ b/tests/e2e/specs/plugin-update.spec.ts
@@ -1,55 +1,48 @@
 import { expect, test } from '@playwright/test';
 import { getInstalledPluginVersion } from '../helpers/wp-cli.js';
-import { loginAsAdmin } from '../helpers/wp-admin.js';
-import { statusText, waitForSandboxReady } from '../helpers/sandbox.js';
+import { waitForSandboxReady } from '../helpers/sandbox.js';
 
 const PERFORMANCE_LAB_ENTRY = 'performance-lab/load.php';
 
-// Failure-mode note for whoever lands here on a red CI:
-// This spec is a real-bug detector for the host→Playground upgrade
-// flow, not just a UI assertion. If `statusText` ends up containing
-// "Upgrade test failed: No upgrade link found on plugins.php…", the
-// sandbox booted and synced, but Playground's plugins.php didn't
-// render the upgrade row for the entry the test transferred. Causes
-// observed in practice:
-//   - `_site_transient_update_plugins` row not surviving the
-//     wp_options dump → import path (Reprint exporter / SQLite
-//     reimport stripping FROM_BASE64'd serialized data).
-//   - Playground re-running `wp_update_plugins()` on first admin
-//     render and overwriting the synced transient with its own
-//     (possibly empty) result.
-// Either is upstream of this test — investigate the plugin's sync
-// pipeline before relaxing the assertion.
 test.describe('Plugin update in sandbox', () => {
 	test('runs upgrade via in-row link, leaves host plugin untouched', async ({ page }) => {
 		const versionBefore = getInstalledPluginVersion(PERFORMANCE_LAB_ENTRY);
 
-		await loginAsAdmin(page);
 		await page.goto('/wp-admin/plugins.php');
 
-		// The host-side `in_plugin_update_message-<entry>` action appends the
-		// "test the plugin update in the sandbox" anchor inside the per-row
-		// update message. Match by the data attribute so the assertion fails
-		// loudly if the renderer drops the marker.
+		// The host-side `in_plugin_update_message-<entry>` action appends a
+		// "Click here to test the new version before you upgrade." anchor
+		// inside the per-row update message. Match by the data attribute
+		// so the assertion fails loudly if the renderer drops the marker.
 		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${PERFORMANCE_LAB_ENTRY}"]`);
-		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
+		await expect(upgradeLink).toBeVisible();
 		await upgradeLink.click();
 
 		// Run page should boot with testUpgrade in the URL.
 		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(PERFORMANCE_LAB_ENTRY);
 
-		// Wait until the sandbox is far enough along that the upgrade flow
-		// completed. `runTestUpgrade` sets either of these terminal statuses;
-		// poll for the upgrade-in-progress label which is the success signal.
-		await waitForSandboxReady(page).catch(() => {
-			// `runTestUpgrade` clobbers the "Ready" status with its own
-			// progress message, so a missed "Ready" isn't a failure. Fall
-			// through to the upgrade-state assertion below.
+		await waitForSandboxReady(page);
+
+		// Real success signal: the Playground iframe reaches WP's upgrade
+		// landing page for this plugin entry. The runtime nonce is unknown
+		// ahead of time so we match on the action + plugin path and
+		// require a hex `_wpnonce` to be present.
+		const upgradeUrlPattern =
+			/\/wp-admin\/update\.php\?action=upgrade-plugin&plugin=performance-lab%2Fload\.php&_wpnonce=[a-f0-9]+/;
+		await expect
+			.poll(() => page.frames().find((f) => upgradeUrlPattern.test(f.url()))?.url() ?? null, {
+				timeout: 5 * 1000,
+				message: 'Playground iframe should land on update.php?action=upgrade-plugin for this entry',
+			})
+			.toMatch(upgradeUrlPattern);
+
+		// Upgrade completion is signalled inside the Playground WP frame
+		// by the "Go to Plugins page" link rendered after a successful
+		// update.php run.
+		const playgroundFrame = page.frameLocator('#lse-preview-iframe').frameLocator('iframe');
+		await expect(playgroundFrame.getByRole('link', { name: 'Go to Plugins page' })).toBeVisible({
+			timeout: 5 * 1000,
 		});
-		await expect(statusText(page)).toContainText(/Upgrade in progress|Upgrade test failed|Preparing upgrade test/i, {
-			timeout: 4 * 60 * 1000,
-		});
-		await expect(statusText(page)).not.toContainText(/failed/i);
 
 		const versionAfter = getInstalledPluginVersion(PERFORMANCE_LAB_ENTRY);
 		expect(versionAfter, 'host plugin version must not change').toBe(versionBefore);

--- a/tests/e2e/specs/quick-links.spec.ts
+++ b/tests/e2e/specs/quick-links.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { loginAsAdmin, runPageUrl } from '../helpers/wp-admin.js';
+import { runPageUrl } from '../helpers/wp-admin.js';
 import { urlInput, waitForSandboxReady } from '../helpers/sandbox.js';
 
 const QUICK_LINKS: ReadonlyArray<{ label: string; path: string }> = [
@@ -13,7 +13,6 @@ const QUICK_LINKS: ReadonlyArray<{ label: string; path: string }> = [
 
 test.describe('Quick links menu', () => {
 	test('renders all quick links and navigates to each', async ({ page }) => {
-		await loginAsAdmin(page);
 		await page.goto(runPageUrl());
 		await waitForSandboxReady(page);
 
@@ -26,16 +25,19 @@ test.describe('Quick links menu', () => {
 			await input.click();
 			await expect(menu).toBeVisible();
 
-			const item = menu.getByRole('menuitem', { name: new RegExp(`^${escapeRegex(link.label)}`) });
-			await expect(item).toBeVisible();
+			// Match the menuitem whose label span text equals `link.label`
+			// exactly. Scoping to the label span avoids matching against the
+			// menuitem's full accessible name, which concatenates the label
+			// and path spans.
+			const item = menu.locator('.lse-url-menu-item').filter({
+				has: page.getByText(link.label, { exact: true }),
+			});
 			await item.click();
 
 			await expect(menu).toBeHidden();
-			await expect(input).toHaveValue(new RegExp(escapeRegex(link.path)));
+			// `quickNavigate` writes the path into `state.url` literally —
+			// assert against the exact string.
+			await expect(input).toHaveValue(link.path);
 		}
 	});
 });
-
-function escapeRegex(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}

--- a/tests/e2e/specs/quick-links.spec.ts
+++ b/tests/e2e/specs/quick-links.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin, runPageUrl } from '../helpers/wp-admin.js';
+import { urlInput, waitForSandboxReady } from '../helpers/sandbox.js';
+
+const QUICK_LINKS: ReadonlyArray<{ label: string; path: string }> = [
+	{ label: 'Homepage', path: '/' },
+	{ label: 'Dashboard', path: '/wp-admin/' },
+	{ label: 'Site Editor', path: '/wp-admin/site-editor.php' },
+	{ label: 'New Post', path: '/wp-admin/post-new.php' },
+	{ label: 'Plugins', path: '/wp-admin/plugins.php' },
+	{ label: 'Themes', path: '/wp-admin/themes.php' },
+];
+
+test.describe('Quick links menu', () => {
+	test('renders all quick links and navigates to each', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(runPageUrl());
+		await waitForSandboxReady(page);
+
+		const input = urlInput(page);
+		const menu = page.locator('#lse-url-menu');
+
+		for (const link of QUICK_LINKS) {
+			// Re-open the menu each iteration: clicking a menu item closes it
+			// via the `urlMenuOpen` signal flip in `quickNavigate`.
+			await input.click();
+			await expect(menu).toBeVisible();
+
+			const item = menu.getByRole('menuitem', { name: new RegExp(`^${escapeRegex(link.label)}`) });
+			await expect(item).toBeVisible();
+			await item.click();
+
+			await expect(menu).toBeHidden();
+			await expect(input).toHaveValue(new RegExp(escapeRegex(link.path)));
+		}
+	});
+});
+
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/e2e/specs/setup-flow.spec.ts
+++ b/tests/e2e/specs/setup-flow.spec.ts
@@ -1,25 +1,40 @@
-import { expect, test } from '@playwright/test';
-import { loginAsAdmin, setupPageUrl } from '../helpers/wp-admin.js';
+import { type Locator, type Page, expect, test } from '@playwright/test';
+import { setupPageUrl } from '../helpers/wp-admin.js';
 import { waitForSandboxReady } from '../helpers/sandbox.js';
+
+function groupFieldset(page: Page, legend: 'Plugins' | 'Themes' | 'Tables'): Locator {
+	return page.locator('fieldset.lse-setup-group').filter({ has: page.getByText(legend, { exact: true }) });
+}
+
+function itemCheckboxes(group: Locator): Locator {
+	return group.getByRole('checkbox');
+}
+
+// Bulk-action button names share a prefix ("Select all" ⊂ "Select
+// active"), so a default substring match would resolve to multiple
+// elements and trip Playwright's strict-mode locator check. Always
+// require an exact-name match.
+function bulkAction(group: Locator, action: 'Select all' | 'Select active' | 'Deselect all'): Locator {
+	return group.getByRole('button', { name: action, exact: true });
+}
 
 test.describe('Setup flow', () => {
 	test('Setup → Run forwards manifest selections to the Run page', async ({ page }) => {
-		await loginAsAdmin(page);
-		await page.goto(setupPageUrl());
+await page.goto(setupPageUrl());
 
 		// The setup view is hidden behind a loading paragraph until the
 		// /sync-manifest?labels=1 fetch returns. The Run button becomes
 		// clickable when at least one item is selected; defaults select all
 		// active plugins/themes/tables so it's enabled on first paint.
 		const runButton = page.getByRole('button', { name: 'Run' });
-		await expect(runButton).toBeEnabled({ timeout: 30 * 1000 });
+		await expect(runButton).toBeEnabled();
 
 		// Deselect everything in plugins then re-select only the active ones.
 		// This exercises the "Select active" action and proves the resulting
 		// manifest reflects the current state of checkboxes.
-		const pluginsGroup = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Plugins', { exact: true }) });
-		await pluginsGroup.getByRole('button', { name: 'Deselect all' }).click();
-		await pluginsGroup.getByRole('button', { name: 'Select active' }).click();
+		const plugins = groupFieldset(page, 'Plugins');
+		await bulkAction(plugins, 'Deselect all').click();
+		await bulkAction(plugins, 'Select active').click();
 
 		// Toggle uploads on so it shows up in the manifest payload.
 		await page.getByLabel(/Include wp-content\/uploads/).check();
@@ -47,20 +62,177 @@ test.describe('Setup flow', () => {
 		await waitForSandboxReady(page);
 	});
 
-	test('Setup defaults match active plugins/themes', async ({ page }) => {
-		await loginAsAdmin(page);
+	test('Setup defaults: active plugins/themes checked, all tables checked, uploads off', async ({ page }) => {
+await page.goto(setupPageUrl());
+
+		await expect(page.getByRole('button', { name: 'Run' })).toBeEnabled();
+
+		// performance-lab is active in the wp-env setup project, so its row
+		// is in the plugins list and the checkbox is checked by default —
+		// `default_active_plugins()` seeds the manifest.
+		const plugins = groupFieldset(page, 'Plugins');
+		await expect(plugins.locator('ul li').filter({ hasText: 'Performance Lab' }).getByRole('checkbox')).toBeChecked();
+
+		// Themes: the active stylesheet (and its parent if different) must be
+		// the only checked rows. wp-env's default WP install ships with a
+		// current Twenty Twenty-X theme active, so at least one theme row is
+		// checked and the count is non-zero.
+		const themes = groupFieldset(page, 'Themes');
+		const themesCheckboxes = itemCheckboxes(themes);
+		await expect(themesCheckboxes).not.toHaveCount(0);
+		const checkedThemes = themes.locator('ul li input[type="checkbox"]:checked');
+		await expect(checkedThemes, 'at least one theme is checked by default').not.toHaveCount(0);
+
+		// Tables: every row in the tables fieldset is pre-selected. The setup
+		// store seeds tables with `selected: true` for every row returned by
+		// the manifest endpoint, so total === checked.
+		const tables = groupFieldset(page, 'Tables');
+		const tableCheckboxes = itemCheckboxes(tables);
+		await expect(tableCheckboxes, 'tables list is populated').not.toHaveCount(0);
+		const checkedTables = tables.locator('ul li input[type="checkbox"]:checked');
+		const totalTables = await tableCheckboxes.count();
+		await expect(checkedTables, 'every table row is checked by default').toHaveCount(totalTables);
+
+		// Uploads: default manifest carries `uploads: false`, so the toggle
+		// renders unchecked.
+		await expect(page.getByLabel(/Include wp-content\/uploads/)).not.toBeChecked();
+	});
+
+	test('Bulk actions: Select all / Select active / Deselect all, and empty selection disables Run', async ({ page }) => {
+await page.goto(setupPageUrl());
+
+		const runButton = page.getByRole('button', { name: 'Run' });
+		await expect(runButton).toBeEnabled();
+
+		// Web-first count assertions so we ride out async Interactivity API
+		// store updates without re-implementing retry. The `:checked`
+		// pseudo-class can't appear under `getByRole`, hence the CSS
+		// scoping here. The 'active' branch lives at the caller — it
+		// compares two checkbox-state snapshots and needs an array, not a
+		// count.
+		const assertChecked = async (group: Locator, expected: 'all' | 'none'): Promise<void> => {
+			const boxes = itemCheckboxes(group);
+			const checked = group.locator('ul li input[type="checkbox"]:checked');
+			if (expected === 'all') {
+				const total = await boxes.count();
+				expect(total, 'group has rows').toBeGreaterThan(0);
+				await expect(checked).toHaveCount(total);
+			} else {
+				await expect(checked).toHaveCount(0);
+			}
+		};
+
+		for (const legend of ['Plugins', 'Themes'] as const) {
+			const group = groupFieldset(page, legend);
+
+			// Snapshot the initial "active" state so we can compare it to the
+			// result of "Select active" later.
+			const initialActive = await itemCheckboxes(group).evaluateAll((els) =>
+				(els as HTMLInputElement[]).map((el) => el.checked),
+			);
+
+			await bulkAction(group, 'Select all').click();
+			await assertChecked(group, 'all');
+
+			await bulkAction(group, 'Deselect all').click();
+			await assertChecked(group, 'none');
+
+			await bulkAction(group, 'Select active').click();
+			const afterSelectActive = await itemCheckboxes(group).evaluateAll((els) =>
+				(els as HTMLInputElement[]).map((el) => el.checked),
+			);
+			expect(afterSelectActive, `${legend}: Select active restores the initial active set`).toEqual(initialActive);
+		}
+
+		// Tables only expose Select all / Deselect all (no concept of
+		// "active") — exercise both.
+		const tables = groupFieldset(page, 'Tables');
+		await bulkAction(tables, 'Deselect all').click();
+		await assertChecked(tables, 'none');
+		await bulkAction(tables, 'Select all').click();
+		await assertChecked(tables, 'all');
+
+		// With everything deselected across all three groups (and uploads
+		// off), `runDisabled` flips true and the Run button is no longer
+		// clickable. The setup store derives the disabled state from
+		// `anySelected || uploads`, so clear everything to hit that branch.
+		for (const legend of ['Plugins', 'Themes', 'Tables'] as const) {
+			await bulkAction(groupFieldset(page, legend), 'Deselect all').click();
+		}
+		await expect(page.getByLabel(/Include wp-content\/uploads/)).not.toBeChecked();
+		await expect(runButton).toBeDisabled();
+
+		// Sanity: flipping uploads on by itself re-enables Run, confirming
+		// the disabled state was bound to selection state and not stuck.
+		await page.getByLabel(/Include wp-content\/uploads/).check();
+		await expect(runButton).toBeEnabled();
+	});
+
+	test('Setup → Run with only uploads selected forwards an uploads-only manifest', async ({ page }) => {
 		await page.goto(setupPageUrl());
 
-		await expect(page.getByRole('button', { name: 'Run' })).toBeEnabled({ timeout: 30 * 1000 });
+		const runButton = page.getByRole('button', { name: 'Run' });
+		await expect(runButton).toBeEnabled();
 
-		// performance-lab is installed and activated by global-setup, so it
-		// must appear in the plugins list as a checked item by default.
-		const pluginsList = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Plugins', { exact: true }) }).locator('ul li');
-		await expect(pluginsList.filter({ hasText: 'Performance Lab' }).locator('input[type="checkbox"]').first()).toBeChecked();
+		for (const legend of ['Plugins', 'Themes', 'Tables'] as const) {
+			await bulkAction(groupFieldset(page, legend), 'Deselect all').click();
+		}
+		await page.getByLabel(/Include wp-content\/uploads/).check();
+		await expect(runButton).toBeEnabled();
 
-		// Tables fieldset should always contain the core wp_options-style
-		// list with everything pre-selected.
-		const tablesList = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Tables', { exact: true }) }).locator('ul li');
-		await expect(tablesList.first()).toBeVisible();
+		const navigation = page.waitForURL((u) => u.searchParams.has('manifest'));
+		await runButton.click();
+		await navigation;
+
+		const manifest = JSON.parse(new URL(page.url()).searchParams.get('manifest') ?? '{}') as {
+			plugins: string[];
+			themes: string[];
+			tables: string[];
+			uploads: boolean;
+		};
+		expect(manifest.uploads).toBe(true);
+		expect(manifest.plugins).toEqual([]);
+		expect(manifest.themes).toEqual([]);
+		expect(manifest.tables).toEqual([]);
+	});
+
+	test('Individual row toggle drives Run-enabled state and the resulting manifest', async ({ page }) => {
+		await page.goto(setupPageUrl());
+
+		const runButton = page.getByRole('button', { name: 'Run' });
+		await expect(runButton).toBeEnabled();
+
+		// Start from an empty selection so the only way Run can re-enable
+		// is via the single-row check we exercise below.
+		for (const legend of ['Plugins', 'Themes', 'Tables'] as const) {
+			await bulkAction(groupFieldset(page, legend), 'Deselect all').click();
+		}
+		await expect(runButton).toBeDisabled();
+
+		// performance-lab is seeded by the wp-env setup project; its
+		// `id` is the entry path "performance-lab/load.php" (see
+		// `buildItems` in src/setup.ts), which is what lands in the
+		// manifest array.
+		const plugins = groupFieldset(page, 'Plugins');
+		const perfLabRow = plugins.locator('ul li').filter({ hasText: 'Performance Lab' });
+		const perfLabBox = perfLabRow.getByRole('checkbox');
+		await perfLabBox.check();
+		await expect(perfLabBox).toBeChecked();
+		await expect(runButton).toBeEnabled();
+
+		const navigation = page.waitForURL((u) => u.searchParams.has('manifest'));
+		await runButton.click();
+		await navigation;
+
+		const manifest = JSON.parse(new URL(page.url()).searchParams.get('manifest') ?? '{}') as {
+			plugins: string[];
+			themes: string[];
+			tables: string[];
+			uploads: boolean;
+		};
+		expect(manifest.plugins).toEqual(['performance-lab/load.php']);
+		expect(manifest.themes).toEqual([]);
+		expect(manifest.tables).toEqual([]);
+		expect(manifest.uploads).toBe(false);
 	});
 });

--- a/tests/e2e/specs/setup-flow.spec.ts
+++ b/tests/e2e/specs/setup-flow.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin, setupPageUrl } from '../helpers/wp-admin.js';
+import { waitForSandboxReady } from '../helpers/sandbox.js';
+
+test.describe('Setup flow', () => {
+	test('Setup → Run forwards manifest selections to the Run page', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(setupPageUrl());
+
+		// The setup view is hidden behind a loading paragraph until the
+		// /sync-manifest?labels=1 fetch returns. The Run button becomes
+		// clickable when at least one item is selected; defaults select all
+		// active plugins/themes/tables so it's enabled on first paint.
+		const runButton = page.getByRole('button', { name: 'Run' });
+		await expect(runButton).toBeEnabled({ timeout: 30 * 1000 });
+
+		// Deselect everything in plugins then re-select only the active ones.
+		// This exercises the "Select active" action and proves the resulting
+		// manifest reflects the current state of checkboxes.
+		const pluginsGroup = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Plugins', { exact: true }) });
+		await pluginsGroup.getByRole('button', { name: 'Deselect all' }).click();
+		await pluginsGroup.getByRole('button', { name: 'Select active' }).click();
+
+		// Toggle uploads on so it shows up in the manifest payload.
+		await page.getByLabel(/Include wp-content\/uploads/).check();
+
+		// Capture the navigation triggered by the Run button so we can assert
+		// against the resulting URL (the action assigns window.location with
+		// the manifest as a query parameter).
+		const navigation = page.waitForURL((u) => u.searchParams.has('manifest'));
+		await runButton.click();
+		await navigation;
+
+		const manifestRaw = new URL(page.url()).searchParams.get('manifest');
+		expect(manifestRaw, 'manifest query param is set').not.toBeNull();
+		const manifest = JSON.parse(manifestRaw ?? '{}') as {
+			plugins: string[];
+			themes: string[];
+			tables: string[];
+			uploads: boolean;
+		};
+		expect(manifest.uploads).toBe(true);
+		expect(Array.isArray(manifest.plugins)).toBe(true);
+		expect(Array.isArray(manifest.themes)).toBe(true);
+		expect(Array.isArray(manifest.tables)).toBe(true);
+
+		await waitForSandboxReady(page);
+	});
+
+	test('Setup defaults match active plugins/themes', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(setupPageUrl());
+
+		await expect(page.getByRole('button', { name: 'Run' })).toBeEnabled({ timeout: 30 * 1000 });
+
+		// performance-lab is installed and activated by global-setup, so it
+		// must appear in the plugins list as a checked item by default.
+		const pluginsList = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Plugins', { exact: true }) }).locator('ul li');
+		await expect(pluginsList.filter({ hasText: 'Performance Lab' }).locator('input[type="checkbox"]').first()).toBeChecked();
+
+		// Tables fieldset should always contain the core wp_options-style
+		// list with everything pre-selected.
+		const tablesList = page.locator('fieldset.lse-setup-group').filter({ has: page.getByText('Tables', { exact: true }) }).locator('ul li');
+		await expect(tablesList.first()).toBeVisible();
+	});
+});

--- a/tests/e2e/specs/theme-update.spec.ts
+++ b/tests/e2e/specs/theme-update.spec.ts
@@ -1,29 +1,28 @@
 import { expect, test } from '@playwright/test';
 import { getInstalledThemeVersion } from '../helpers/wp-cli.js';
-import { loginAsAdmin } from '../helpers/wp-admin.js';
 import { statusText, waitForSandboxReady } from '../helpers/sandbox.js';
 
 const THEME_STYLESHEET = 'twentyeleven';
 
-// The host-side theme-update entry point mirrors `inc/test-upgrade.php`:
-// a `[data-lse-test-upgrade="<stylesheet>"]` anchor pointing at the Run
-// page with `?testUpgrade=<stylesheet>`. The feature is not implemented
-// yet — these specs are marked `.fixme` so they're visible in the runner
-// output but don't fail the suite. Drop `.fixme` once the link renders.
+// Host-side theme-update entry point: `inc/test-upgrade.php`
+// `render_theme_link()` emits
+//   <a class="lse-test-upgrade-link" data-lse-test-theme-upgrade="<slug>" href="…?testThemeUpgrade=<slug>">
+// inside themes.php's per-card "New version available" notice (via
+// `wp_prepare_themes_for_js` injection). Same shape as the plugin spec
+// but distinct attribute + query param.
 test.describe('Theme update in sandbox', () => {
-	test.fixme('runs upgrade via link on themes.php (all themes), leaves host theme untouched', async ({ page }) => {
+	test('runs upgrade via link on themes.php (all themes), leaves host theme untouched', async ({ page }) => {
 		const versionBefore = getInstalledThemeVersion(THEME_STYLESHEET);
 
-		await loginAsAdmin(page);
-		await page.goto('/wp-admin/themes.php');
+await page.goto('/wp-admin/themes.php');
 
-		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${THEME_STYLESHEET}"]`);
-		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
+		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-theme-upgrade="${THEME_STYLESHEET}"]`);
+		await expect(upgradeLink).toBeVisible();
 		await upgradeLink.click();
 
-		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(THEME_STYLESHEET);
+		await expect.poll(() => new URL(page.url()).searchParams.get('testThemeUpgrade')).toBe(THEME_STYLESHEET);
 
-		await waitForSandboxReady(page).catch(() => undefined);
+		await waitForSandboxReady(page);
 		await expect(statusText(page)).toContainText(/Upgrade in progress|Preparing upgrade test/i, {
 			timeout: 4 * 60 * 1000,
 		});
@@ -33,25 +32,27 @@ test.describe('Theme update in sandbox', () => {
 		expect(versionAfter, 'host theme version must not change').toBe(versionBefore);
 	});
 
-	test.fixme('runs upgrade via link on the single-theme view, leaves host theme untouched', async ({ page }) => {
+	test('runs upgrade via link on the single-theme view, leaves host theme untouched', async ({ page }) => {
 		const versionBefore = getInstalledThemeVersion(THEME_STYLESHEET);
 
-		await loginAsAdmin(page);
-		await page.goto(`/wp-admin/theme-install.php?theme=${THEME_STYLESHEET}`);
-		// The single-theme view is the themes.php modal that opens when the
-		// user clicks a theme card. Open it through the theme detail URL so
-		// the test doesn't rely on JS-driven modal state.
+// themes.php?theme=<slug> opens the per-theme details modal on
+		// load (WP's themes-grid JS reads the query param and shows the
+		// overlay). The injected sandbox-link sits inside the same
+		// "New version available" notice as the grid card.
 		await page.goto(`/wp-admin/themes.php?theme=${THEME_STYLESHEET}`);
 
-		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${THEME_STYLESHEET}"]`);
-		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
-		await upgradeLink.click();
+		const modalLink = page
+			.locator('.theme-overlay, #theme-overlay')
+			.locator(`a.lse-test-upgrade-link[data-lse-test-theme-upgrade="${THEME_STYLESHEET}"]`);
+		await expect(modalLink).toBeVisible();
+		await modalLink.click();
 
-		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(THEME_STYLESHEET);
-		await waitForSandboxReady(page).catch(() => undefined);
+		await expect.poll(() => new URL(page.url()).searchParams.get('testThemeUpgrade')).toBe(THEME_STYLESHEET);
+		await waitForSandboxReady(page);
 		await expect(statusText(page)).toContainText(/Upgrade in progress|Preparing upgrade test/i, {
 			timeout: 4 * 60 * 1000,
 		});
+		await expect(statusText(page)).not.toContainText(/failed/i);
 
 		const versionAfter = getInstalledThemeVersion(THEME_STYLESHEET);
 		expect(versionAfter, 'host theme version must not change').toBe(versionBefore);

--- a/tests/e2e/specs/theme-update.spec.ts
+++ b/tests/e2e/specs/theme-update.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { getInstalledThemeVersion } from '../helpers/wp-cli.js';
+import { loginAsAdmin } from '../helpers/wp-admin.js';
+import { statusText, waitForSandboxReady } from '../helpers/sandbox.js';
+
+const THEME_STYLESHEET = 'twentyeleven';
+
+// The host-side theme-update entry point mirrors `inc/test-upgrade.php`:
+// a `[data-lse-test-upgrade="<stylesheet>"]` anchor pointing at the Run
+// page with `?testUpgrade=<stylesheet>`. The feature is not implemented
+// yet — these specs are marked `.fixme` so they're visible in the runner
+// output but don't fail the suite. Drop `.fixme` once the link renders.
+test.describe('Theme update in sandbox', () => {
+	test.fixme('runs upgrade via link on themes.php (all themes), leaves host theme untouched', async ({ page }) => {
+		const versionBefore = getInstalledThemeVersion(THEME_STYLESHEET);
+
+		await loginAsAdmin(page);
+		await page.goto('/wp-admin/themes.php');
+
+		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${THEME_STYLESHEET}"]`);
+		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
+		await upgradeLink.click();
+
+		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(THEME_STYLESHEET);
+
+		await waitForSandboxReady(page).catch(() => undefined);
+		await expect(statusText(page)).toContainText(/Upgrade in progress|Preparing upgrade test/i, {
+			timeout: 4 * 60 * 1000,
+		});
+		await expect(statusText(page)).not.toContainText(/failed/i);
+
+		const versionAfter = getInstalledThemeVersion(THEME_STYLESHEET);
+		expect(versionAfter, 'host theme version must not change').toBe(versionBefore);
+	});
+
+	test.fixme('runs upgrade via link on the single-theme view, leaves host theme untouched', async ({ page }) => {
+		const versionBefore = getInstalledThemeVersion(THEME_STYLESHEET);
+
+		await loginAsAdmin(page);
+		await page.goto(`/wp-admin/theme-install.php?theme=${THEME_STYLESHEET}`);
+		// The single-theme view is the themes.php modal that opens when the
+		// user clicks a theme card. Open it through the theme detail URL so
+		// the test doesn't rely on JS-driven modal state.
+		await page.goto(`/wp-admin/themes.php?theme=${THEME_STYLESHEET}`);
+
+		const upgradeLink = page.locator(`a.lse-test-upgrade-link[data-lse-test-upgrade="${THEME_STYLESHEET}"]`);
+		await expect(upgradeLink).toBeVisible({ timeout: 30 * 1000 });
+		await upgradeLink.click();
+
+		await expect.poll(() => new URL(page.url()).searchParams.get('testUpgrade')).toBe(THEME_STYLESHEET);
+		await waitForSandboxReady(page).catch(() => undefined);
+		await expect(statusText(page)).toContainText(/Upgrade in progress|Preparing upgrade test/i, {
+			timeout: 4 * 60 * 1000,
+		});
+
+		const versionAfter = getInstalledThemeVersion(THEME_STYLESHEET);
+		expect(versionAfter, 'host theme version must not change').toBe(versionBefore);
+	});
+});

--- a/tests/e2e/specs/toolbar.spec.ts
+++ b/tests/e2e/specs/toolbar.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import { runPageUrl } from '../helpers/wp-admin.js';
+import { urlInput, waitForSandboxReady } from '../helpers/sandbox.js';
+
+test.describe('Sandbox toolbar', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(runPageUrl());
+		await waitForSandboxReady(page);
+	});
+
+	test('URL form submit navigates the Playground iframe', async ({ page }) => {
+		// users.php is always present in a fresh WP install and isn't the
+		// boot URL (`/wp-admin/`), so a successful submit moves the frame
+		// to a screen we can identify by its admin heading.
+		const targetPath = '/wp-admin/users.php';
+
+		const input = urlInput(page);
+		await input.fill(targetPath);
+		await input.press('Enter');
+
+		// Strongest user-visible signal that `client.goTo(targetPath)`
+		// completed: the nested WP frame is rendering the Users admin
+		// screen, whose H1 is exactly "Users". Web-first assertion via
+		// frameLocator chains auto-retries while Playground boots.
+		const wpFrame = page.frameLocator('#lse-preview-iframe').frameLocator('iframe');
+		await expect(wpFrame.locator('h1.wp-heading-inline')).toHaveText('Users');
+	});
+
+	test('Refresh re-navigates the Playground iframe at the current URL', async ({ page }) => {
+		const refresh = page.locator('button[data-wp-on--click="actions.refresh"]');
+		await expect(refresh).toBeEnabled();
+
+		// `actions.refresh` calls `client.goTo(currentUrl)`; the iframe
+		// reloads but its URL doesn't change, and the LSE store doesn't
+		// touch any externally visible state. Strongest reload signal we
+		// can get cross-origin: plant a marker element inside the nested
+		// WP document and assert it's gone after the click. Because the
+		// reload replaces the document, the marker disappears iff the
+		// goTo round-trip actually happened.
+		const playgroundFrame = page.frameLocator('#lse-preview-iframe').frameLocator('iframe');
+		await expect(playgroundFrame.locator('#wpadminbar')).toBeVisible();
+
+		await playgroundFrame.locator('body').evaluate((body) => {
+			const el = document.createElement('div');
+			el.id = 'lse-refresh-marker';
+			body.appendChild(el);
+		});
+
+		await refresh.click();
+
+		await expect(playgroundFrame.locator('#lse-refresh-marker')).toHaveCount(0);
+		await expect(playgroundFrame.locator('#wpadminbar')).toBeVisible();
+	});
+
+	test('Editor toggle opens and closes the editor pane', async ({ page }) => {
+		const toggle = page.locator('button[data-wp-on--click="actions.toggleEditor"]');
+		const main = page.locator('.lse-main');
+
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		await expect(main).not.toHaveClass(/(^|\s)editor-open(\s|$)/);
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+		await expect(main).toHaveClass(/(^|\s)editor-open(\s|$)/);
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		await expect(main).not.toHaveClass(/(^|\s)editor-open(\s|$)/);
+	});
+
+	test('Theme toggle switches color scheme across System, Light and Dark', async ({ page }) => {
+		// The radiogroup lives inside `.lse-editor-pane`, which is
+		// `display:none` until `.lse-main.editor-open` flips on. Open
+		// the editor first so the radios are visible / clickable.
+		await page.locator('button[data-wp-on--click="actions.toggleEditor"]').click();
+		await expect(page.locator('.lse-main')).toHaveClass(/(^|\s)editor-open(\s|$)/);
+
+		const radiogroup = page.locator('.lse-theme-toggle');
+		const option = (label: 'System' | 'Light' | 'Dark') =>
+			radiogroup.getByRole('radio', { name: label, exact: true });
+		const root = page.locator('#live-sandbox-editor-root');
+
+		// `setThemeMode` short-circuits when the value matches the
+		// current mode (default is 'system' unless localStorage carries
+		// another choice), so always step through Light → Dark → System
+		// to guarantee each click flips state.
+		await option('Light').click();
+		await expect(option('Light')).toBeChecked();
+		await expect(option('Dark')).not.toBeChecked();
+		await expect(option('System')).not.toBeChecked();
+		await expect(option('Light')).toHaveClass(/(^|\s)is-active(\s|$)/);
+		await expect(root).toHaveAttribute('style', /color-scheme:\s*light(?!\s*dark)/);
+
+		await option('Dark').click();
+		await expect(option('Dark')).toBeChecked();
+		await expect(option('Dark')).toHaveClass(/(^|\s)is-active(\s|$)/);
+		await expect(root).toHaveAttribute('style', /color-scheme:\s*dark/);
+
+		await option('System').click();
+		await expect(option('System')).toBeChecked();
+		await expect(option('System')).toHaveClass(/(^|\s)is-active(\s|$)/);
+		// `colorScheme` resolves to "light dark" in system mode.
+		await expect(root).toHaveAttribute('style', /color-scheme:\s*light\s+dark/);
+	});
+});

--- a/tests/e2e/wp-env.setup.ts
+++ b/tests/e2e/wp-env.setup.ts
@@ -1,0 +1,43 @@
+/**
+ * Playwright "setup project" that runs once before the chromium spec
+ * project (wired through `dependencies: ['wp-env']` in
+ * playwright.config.ts).
+ *
+ * Booting wp-env itself happens at config-load time in
+ * playwright.config.ts via `ensureWpEnvRunning()` — by the time these
+ * tests execute the dev site is reachable. The remaining job is to
+ * prime the WordPress install with the fixtures the specs depend on:
+ * deliberately outdated copies of performance-lab and
+ * twentytwentyeleven so the .org update API reports a new version and
+ * the per-row "test the update in the sandbox" links render.
+ */
+import { test as setup } from '@playwright/test';
+import { wpCli } from './helpers/wp-cli.js';
+
+const PERFORMANCE_LAB_OLD_VERSION = '3.0.0';
+const TWENTY_ELEVEN_OLD_VERSION = '4.0';
+
+setup('test fixtures installed', async () => {
+	// Install older versions on purpose: an update must be available for
+	// the host-side "test the plugin/theme update in the sandbox" link
+	// to render, which is what the plugin- and theme-update specs click
+	// on. `--force` lets the install overwrite a newer copy left over
+	// from a previous run so the suite is rerunnable without a fresh
+	// wp-env.
+	wpCli(['plugin', 'install', 'performance-lab', `--version=${PERFORMANCE_LAB_OLD_VERSION}`, '--force', '--activate']);
+	wpCli(['theme', 'install', 'twentyeleven', `--version=${TWENTY_ELEVEN_OLD_VERSION}`, '--force']);
+
+	// Wipe the cached update-check transients so the next API call
+	// doesn't short-circuit on a stale "no updates" result from a
+	// previous run. `ignoreErrors` covers the first-run case where the
+	// transient hasn't been written yet.
+	wpCli(['transient', 'delete', 'update_plugins'], { ignoreErrors: true });
+	wpCli(['transient', 'delete', 'update_themes'], { ignoreErrors: true });
+
+	// Force WP to query the .org update API now so plugins.php /
+	// themes.php render the "new version available" rows the
+	// upgrade-link tests need. Without this, the first page render
+	// happens before the cron-scheduled check runs and the rows are
+	// missing.
+	wpCli(['eval', 'wp_update_plugins(); wp_update_themes();']);
+});

--- a/tests/mu-plugins/disable-admin-pointers.php
+++ b/tests/mu-plugins/disable-admin-pointers.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name: LSE Tests — Disable Admin Pointers
+ * Description: Hides WordPress's "welcome" admin pointers during
+ *              Playwright runs. They overlay row-action links on
+ *              plugins.php / themes.php and intercept the clicks the
+ *              upgrade-link specs depend on. CSS hide (with !important)
+ *              keeps the pointer markup in the DOM but invisible and
+ *              non-interactive — sufficient for Playwright's
+ *              actionability check.
+ *
+ * Loaded as an mu-plugin via the `mappings` entry in tests/.wp-env.json.
+ */
+
+// phpcs:disable WordPress.WP.EnqueuedResources
+
+namespace LSE\Tests\NoPointers;
+
+\defined( 'ABSPATH' ) || exit;
+
+\add_action(
+	'admin_head',
+	static function (): void {
+		echo '<style id="lse-tests-no-pointers">.wp-pointer{display:none!important}</style>';
+	}
+);

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": ["@tsconfig/strictest/tsconfig"],
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
+		"noEmit": true,
+		"types": ["node"],
+		"paths": {}
+	},
+	"include": ["**/*.ts"]
+}


### PR DESCRIPTION
Adds an admin-auth setup project, toolbar coverage (URL navigate, refresh, editor toggle, theme mode) and two setup-flow cases (uploads-only manifest, individual-row toggle). Replaces the status-text ready signal with sticky DOM bindings, strengthens plugin-update to assert the iframe upgrade URL and success link, and switches checkbox / radio assertions to web-first matchers.